### PR TITLE
feat: increase log level for specific modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,46 @@ yarn
 #   - As a result, new Composable Cow orders will be discovered and posted to the OrderBook API
 yarn ts-node ./src/index.ts run --rpc <rpc-url> --deployment-block <deployment-block> --page-size 0
 ```
+
+## Logging
+
+To control logging level, you can set the `LOG_LEVEL` environment variable with one of the following values: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `SILENT`:
+
+```ini
+LOG_LEVEL=WARN
+```
+
+Additionally, you can enable module specific logging by setting the `DEBUG` environment variable with a comma separated list of modules:
+
+```ini
+# Enable logging for an specific module (chainContext in this case)
+DEBUG=chainContext=INFO
+```
+
+You can specify more than one overrides
+
+```ini
+DEBUG=chainContext=INFO,_placeOrder=TRACE
+```
+
+The module definition is actually a regex pattern, so you can make more complex definitions:
+
+```ini
+# Match a logger using a pattern
+#  Matches: chainContext:processBlock:100:30212964
+#  Matches: chainContext:processBlock:1:30212964
+#  Matches: chainContext:processBlock:5:30212964
+DEBUG=chainContext:processBlock:(\d{1,3}):(\d*)$
+
+# Another example
+#  Matches: chainContext:processBlock:100:30212964
+#  Matches: chainContext:processBlock:1:30212964
+#  But not: chainContext:processBlock:5:30212964
+DEBUG=chainContext:processBlock:(100|1):(\d*)$
+```
+
+Combine all of the above to control the log level of any modules:
+
+```ini
+ LOG_LEVEL=WARN DEBUG="commands=DEBUG,^checkForAndPlaceOrder=WARN,^chainContext=INFO,_checkForAndPlaceOrder:1:=INFO" yarn ts-node ./src/index.ts
+```

--- a/src/commands/dumpDb.ts
+++ b/src/commands/dumpDb.ts
@@ -1,12 +1,12 @@
 import { DumpDbOptions, Registry } from "../types";
-import { logger, DBService } from "../utils";
+import { DBService, getLogger } from "../utils";
 
 /**
  * Dump the database as JSON to STDOUT for a given chain ID
  * @param options A dict, but essentially just the chainId
  */
 export async function dumpDb(options: DumpDbOptions) {
-  const log = logger.getLogger("commands:dumpDb");
+  const log = getLogger("commands:dumpDb");
   const { chainId } = options;
 
   Registry.dump(DBService.getInstance(), chainId.toString())

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,5 +1,5 @@
 import { RunOptions } from "../types";
-import { logger, DBService } from "../utils";
+import { getLogger, DBService } from "../utils";
 import { ChainContext } from "../domain";
 
 /**
@@ -7,7 +7,7 @@ import { ChainContext } from "../domain";
  * @param options Specified by the CLI / environment for running the watch-tower
  */
 export async function run(options: RunOptions) {
-  const log = logger.getLogger("commands:run");
+  const log = getLogger("commands:run");
   const { rpc, deploymentBlock, oneShot } = options;
 
   process.on("unhandledRejection", async (error) => {

--- a/src/domain/addContract.ts
+++ b/src/domain/addContract.ts
@@ -1,4 +1,4 @@
-import { logger } from "../utils";
+import { getLogger } from "../utils";
 import { BytesLike, ethers } from "ethers";
 
 import {
@@ -34,7 +34,7 @@ async function _addContract(
   context: ChainContext,
   event: ConditionalOrderCreatedEvent
 ) {
-  const log = logger.getLogger("addContract:_addContract");
+  const log = getLogger("addContract:_addContract");
   const composableCow = ComposableCoW__factory.createInterface();
   const { provider, registry } = context;
   const { transactionHash: tx, blockNumber } = event;
@@ -83,7 +83,7 @@ export async function _registerNewOrder(
   composableCow: ComposableCoWInterface,
   registry: Registry
 ): Promise<{ error: boolean; added: boolean }> {
-  const log = logger.getLogger("addContract:_registerNewOrder");
+  const log = getLogger("addContract:_registerNewOrder");
   const { transactionHash: tx } = event;
   let added = false;
   try {
@@ -180,7 +180,7 @@ export function add(
   composableCow: string,
   registry: Registry
 ) {
-  const log = logger.getLogger("addContract:add");
+  const log = getLogger("addContract:add");
   const { handler, salt, staticInput } = params;
   if (registry.ownerOrders.has(owner)) {
     const conditionalOrders = registry.ownerOrders.get(owner);

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -8,7 +8,7 @@ import { SupportedChainId, OrderBookApi } from "@cowprotocol/cow-sdk";
 import { addContract } from "./addContract";
 import { checkForAndPlaceOrder } from "./checkForAndPlaceOrder";
 import { ethers } from "ethers";
-import { logger, composableCowContract, DBService } from "../utils";
+import { composableCowContract, DBService, getLogger } from "../utils";
 
 const WATCHDOG_FREQUENCY = 5 * 1000; // 5 seconds
 const WATCHDOG_KILL_THRESHOLD = 30 * 1000; // 30 seconds
@@ -77,7 +77,7 @@ export class ChainContext {
    */
   public async warmUp(oneShot?: boolean) {
     const { provider, chainId } = this;
-    const log = logger.getLogger(`chainContext:warmUp:${chainId}`);
+    const log = getLogger(`chainContext:warmUp:${chainId}`);
     const { lastProcessedBlock } = this.registry;
     const { pageSize } = this;
 
@@ -191,7 +191,7 @@ export class ChainContext {
    */
   private async runBlockWatcher() {
     const { provider, registry, chainId } = this;
-    const log = logger.getLogger(`chainContext:warmUp:${chainId}`);
+    const log = getLogger(`chainContext:warmUp:${chainId}`);
     // Watch for new blocks
     log.info("Running block watcher");
     let lastBlockReceived = 0;
@@ -262,9 +262,7 @@ async function processBlock(
   blockTimestampOverride?: number
 ) {
   const { provider, chainId } = context;
-  const log = logger.getLogger(
-    `chainContext:processBlock:${chainId}:${blockNumber}`
-  );
+  const log = getLogger(`chainContext:processBlock:${chainId}:${blockNumber}`);
   const block = await provider.getBlock(blockNumber);
 
   // Transaction watcher for adding new contracts

--- a/src/domain/checkForAndPlaceOrder.ts
+++ b/src/domain/checkForAndPlaceOrder.ts
@@ -17,12 +17,12 @@ import {
   OrderStatus,
 } from "../types";
 import {
-  logger,
   LowLevelError,
   ORDER_NOT_VALID_SELECTOR,
   PROOF_NOT_AUTHED_SELECTOR,
   SINGLE_ORDER_NOT_AUTHED_SELECTOR,
   formatStatus,
+  getLogger,
   handleExecutionError,
   parseCustomError,
   pollConditionalOrder,
@@ -103,12 +103,12 @@ async function _checkForAndPlaceOrder(
   let orderCounter = 0;
 
   const logPrefix = `checkForAndPlaceOrder:_checkForAndPlaceOrder:${chainId}:${blockNumber}`;
-  const log = logger.getLogger(logPrefix);
+  const log = getLogger(logPrefix);
   log.info(`Number of orders: ${numOrders}`);
 
   for (const [owner, conditionalOrders] of ownerOrders.entries()) {
     ownerCounter++;
-    const log = logger.getLogger(`${logPrefix}:${ownerCounter}`);
+    const log = getLogger(`${logPrefix}:${ownerCounter}`);
     const ordersPendingDelete = [];
     // enumerate all the `ConditionalOrder`s for a given owner
     log.info(
@@ -119,7 +119,7 @@ async function _checkForAndPlaceOrder(
       orderCounter++;
       const ownerRef = `${ownerCounter}.${orderCounter}`;
       const orderRef = `${chainId}:${ownerRef}@${blockNumber}`;
-      const log = logger.getLogger(`${logPrefix}:${ownerRef}}`);
+      const log = getLogger(`${logPrefix}:${ownerRef}}`);
       const logOrderDetails = `Processing order from TX ${conditionalOrder.tx} with params:`;
 
       const { result: lastHint } = conditionalOrder.pollResult || {};
@@ -258,7 +258,7 @@ async function _processConditionalOrder(
   orderRef: string
 ): Promise<PollResult> {
   const { provider, orderBook, dryRun, chainId } = context;
-  const log = logger.getLogger(
+  const log = getLogger(
     `checkForAndPlaceOrder:_processConditionalOrder:${orderRef}`
   );
   try {
@@ -429,7 +429,7 @@ async function _placeOrder(params: {
 }): Promise<Omit<PollResultSuccess, "order" | "signature"> | PollResultErrors> {
   const { orderUid, order, orderBook, orderRef, blockTimestamp, dryRun } =
     params;
-  const log = logger.getLogger(`checkForAndPlaceOrder:_placeOrder:${orderRef}`);
+  const log = getLogger(`checkForAndPlaceOrder:_placeOrder:${orderRef}`);
   try {
     const postOrder: OrderCreation = {
       ...order,
@@ -556,7 +556,7 @@ async function _pollLegacy(
   // as we going to use multicall, with `aggregate3Value`, there is no need to do any simulation as the
   // calls are guaranteed to pass, and will return the results, or the reversion within the ABI-encoded data.
   // By not using `populateTransaction`, we avoid an `eth_estimateGas` RPC call.
-  const log = logger.getLogger(`checkForAndPlaceOrder:_pollLegacy:${orderRef}`);
+  const log = getLogger(`checkForAndPlaceOrder:_pollLegacy:${orderRef}`);
   const to = contract.address;
   const data = contract.interface.encodeFunctionData(
     "getTradeableOrderWithSignature",
@@ -607,9 +607,9 @@ function _handleGetTradableOrderCall(
   orderRef: string
 ): PollResultErrors {
   const logPrefix = `checkForAndPlaceOrder:_handleGetTradableOrderCall:${orderRef}`;
-  const log = logger.getLogger(logPrefix);
+  const log = getLogger(logPrefix);
   if (error.code === Logger.errors.CALL_EXCEPTION) {
-    const log = logger.getLogger(`${logPrefix}: CALL_EXCEPTION`);
+    const log = getLogger(`${logPrefix}: CALL_EXCEPTION`);
 
     // Support raw errors (nethermind issue), and parameterised errors (ethers issue)
     const { errorNameOrSelector } = parseCustomError(error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,7 @@
 import { program, Option } from "@commander-js/extra-typings";
 import { ReplayTxOptions } from "./types";
 import { dumpDb, replayBlock, replayTx, run } from "./commands";
-import { logger } from "./utils";
-
-type LogLevelNames = {
-  [K in keyof typeof logger.levels]: K;
-};
+import { setRootLogLevel } from "./utils";
 
 const logLevelOption = new Option("--log-level <logLevel>", "Log level")
   .choices(["INFO", "DEBUG", "TRACE", "WARN", "ERROR", "SILENT"] as const)
@@ -47,7 +43,7 @@ async function main() {
     .action((options) => {
       const { logLevel } = options;
 
-      logger.setDefaultLevel(logLevel as LogLevelNames[keyof LogLevelNames]);
+      setRootLogLevel(logLevel);
       const {
         rpc,
         deploymentBlock: deploymentBlockEnv,

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -3,7 +3,7 @@ import { DBService } from "./db";
 
 import { ExecutionContext, Registry, SingularRunOptions } from "../types";
 import { SupportedChainId } from "@cowprotocol/cow-sdk";
-import { logger } from "./logging";
+import { getLogger } from "./logging";
 
 const NOTIFICATION_WAIT_PERIOD = 1000 * 60 * 60 * 2; // 2h - Don't send more than one notification every 2h
 
@@ -59,7 +59,7 @@ function _getSlack(options: SingularRunOptions): Slack | undefined {
 }
 
 export async function handleExecutionError(e: any) {
-  const log = logger.getLogger("context:handleExecutionError");
+  const log = getLogger("context:handleExecutionError");
   try {
     const errorMessage = e?.message || "Unknown error";
     const notified = sendSlack(
@@ -80,7 +80,7 @@ export async function handleExecutionError(e: any) {
 }
 
 export function sendSlack(message: string): boolean {
-  const log = logger.getLogger("context:sendSlack");
+  const log = getLogger("context:sendSlack");
   if (!executionContext) {
     log.warn("Slack not initialized, ignoring message", message);
     return false;

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -1,6 +1,25 @@
-import log from "loglevel";
+import {
+  setLevel,
+  getLogger as getLoggerLogLevel,
+  LogLevelNames,
+  Logger,
+} from "loglevel";
+import rootLogger from "loglevel";
 import prefix from "loglevel-plugin-prefix";
 import chalk, { Chalk } from "chalk";
+
+const LEVELS = ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "SILENT"];
+
+interface LogLevelOverride {
+  regex: RegExp;
+  level: LogLevelNames;
+}
+
+// Set the default log level
+setRootLogLevel(process.env.LOG_LEVEL || "WARN");
+
+// Init Log level overrides
+const logLevelOverrides = initLogLevelOverrides();
 
 const colors: Record<string, Chalk> = {
   TRACE: chalk.magenta,
@@ -10,10 +29,8 @@ const colors: Record<string, Chalk> = {
   ERROR: chalk.red,
 };
 
-prefix.reg(log);
-log.enableAll();
-
-prefix.apply(log, {
+prefix.reg(rootLogger);
+prefix.apply(rootLogger, {
   timestampFormatter(date) {
     return date.toISOString();
   },
@@ -24,4 +41,64 @@ prefix.apply(log, {
   },
 });
 
-export { log as logger };
+export function getLogger(loggerName: string): Logger {
+  const logger = getLoggerLogLevel(loggerName);
+
+  const logLevelOverride = logLevelOverrides.find((override) =>
+    override.regex.test(loggerName)
+  );
+
+  if (logLevelOverride) {
+    logger.setLevel(logLevelOverride.level);
+  }
+  return logger;
+}
+
+export function setRootLogLevel(level: string) {
+  setLevel(getLogLevel(level));
+}
+
+function initLogLevelOverrides(): LogLevelOverride[] {
+  if (!process.env.DEBUG) {
+    return [];
+  }
+
+  const loggerDefinitions = process.env.DEBUG.split(",").map((logger) =>
+    logger.trim()
+  );
+  return loggerDefinitions.map((loggerDefinition) => {
+    const loggerDef = loggerDefinition
+      .split("=")
+      .map((logger) => logger.trim());
+
+    if (loggerDef.length !== 2) {
+      throw new Error(
+        'Invalid logger definition. Please use "loggerModulePattern=LEVEL". Offending definition: ' +
+          loggerDefinition
+      );
+    }
+
+    try {
+      return {
+        regex: new RegExp(loggerDef[0]),
+        level: getLogLevel(loggerDef[1]),
+      };
+    } catch (e) {
+      throw new Error(
+        `Error parsing logger overrides: "${loggerDefinition}". ${
+          (e as any)?.message
+        }`
+      );
+    }
+  });
+}
+
+function getLogLevel(level: string): LogLevelNames {
+  if (!LEVELS.includes(level)) {
+    throw new Error(
+      `Invalid log level: ${level}. Please use one of ${LEVELS.join(", ")}`
+    );
+  }
+
+  return level.toLowerCase() as LogLevelNames;
+}

--- a/src/utils/poll.ts
+++ b/src/utils/poll.ts
@@ -5,7 +5,7 @@ import {
   PollParams,
   PollResult,
 } from "@cowprotocol/cow-sdk";
-import { logger } from "./logging";
+import { getLogger } from "./logging";
 
 // Watch-tower will index every block, so we will by default the processing block and not the latest.
 const POLL_FROM_LATEST_BLOCK = false;
@@ -19,7 +19,7 @@ export async function pollConditionalOrder(
   conditionalOrderParams: ConditionalOrderParams,
   orderRef: string
 ): Promise<PollResult | undefined> {
-  const log = logger.getLogger(`polling:pollConditionalOrder:${orderRef}`);
+  const log = getLogger(`polling:pollConditionalOrder:${orderRef}`);
   const order = ordersFactory.fromParams(conditionalOrderParams);
 
   if (!order) {


### PR DESCRIPTION
# Description
This PR allows to reduce the root logging level (for example to `WARN` and then raise it for specific modules

All this is done using some log level overrides defined using the env var `DEBUG`

The scope of this PR is better understood by reading the new README section on logging.

READ: https://github.com/cowprotocol/watch-tower/tree/enable-to-raise-specific-modules-log-level#logging 