### PR TITLE
Merge 2 envs for logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,22 @@ To control logging level, you can set the `LOG_LEVEL` environment variable with 
 LOG_LEVEL=WARN
 ```
 
-Additionally, you can enable module specific logging by setting the `DEBUG` environment variable with a comma separated list of modules:
+Additionally, you can enable module specific logging by specifying the log level for the module name:
 
 ```ini
 # Enable logging for an specific module (chainContext in this case)
-DEBUG=chainContext=INFO
+LOG_LEVEL=chainContext=INFO
+
+# Of-course, you can provide the root log level, and the override at the same time
+#   - All loggers will have WARN level
+#   - Except the "chainContext" which will have INFO level
+LOG_LEVEL=WARN,chainContext=INFO
 ```
 
 You can specify more than one overrides
 
 ```ini
-DEBUG=chainContext=INFO,_placeOrder=TRACE
+LOG_LEVEL=chainContext=INFO,_placeOrder=TRACE
 ```
 
 The module definition is actually a regex pattern, so you can make more complex definitions:
@@ -98,17 +103,17 @@ The module definition is actually a regex pattern, so you can make more complex 
 #  Matches: chainContext:processBlock:100:30212964
 #  Matches: chainContext:processBlock:1:30212964
 #  Matches: chainContext:processBlock:5:30212964
-DEBUG=chainContext:processBlock:(\d{1,3}):(\d*)$
+LOG_LEVEL=chainContext:processBlock:(\d{1,3}):(\d*)$=DEBUG
 
 # Another example
 #  Matches: chainContext:processBlock:100:30212964
 #  Matches: chainContext:processBlock:1:30212964
 #  But not: chainContext:processBlock:5:30212964
-DEBUG=chainContext:processBlock:(100|1):(\d*)$
+LOG_LEVEL=chainContext:processBlock:(100|1):(\d*)$=DEBUG
 ```
 
 Combine all of the above to control the log level of any modules:
 
 ```ini
- LOG_LEVEL=WARN DEBUG="commands=DEBUG,^checkForAndPlaceOrder=WARN,^chainContext=INFO,_checkForAndPlaceOrder:1:=INFO" yarn ts-node ./src/index.ts
+ LOG_LEVEL="WARN,commands=DEBUG,^checkForAndPlaceOrder=WARN,^chainContext=INFO,_checkForAndPlaceOrder:1:=INFO" yarn ts-node ./src/index.ts
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cowprotocol/watch-tower",
   "license": "GPL-3.0-or-later",
-  "version": "1.0.1-rc.0",
+  "version": "1.0.0-rc.1",
   "description": "A standalone watch tower, keeping an eye on Composable Cows  👀🐮",
   "author": {
     "name": "Cow Protocol"

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -141,7 +141,7 @@ export class ChainContext {
 
       // Replay only the blocks that had some events.
       for (const [blockNumber, events] of Object.entries(plan)) {
-        log.trace(`[run_rebuild] Processing block ${blockNumber}`);
+        log.debug(`[run_rebuild] Processing block ${blockNumber}`);
         try {
           await processBlock(
             this,
@@ -158,7 +158,7 @@ export class ChainContext {
           log.error(`Error processing block ${blockNumber}`, err);
         }
 
-        log.trace(`Block ${blockNumber} has been processed`);
+        log.debug(`Block ${blockNumber} has been processed`);
       }
 
       // Set the last processed block to the current block number
@@ -248,7 +248,7 @@ export class ChainContext {
       const currentTime = new Date().getTime();
       const timeElapsed = currentTime - timeLastBlockProcessed;
 
-      log.trace(`Time since last block processed: ${timeElapsed}ms`);
+      log.debug(`Time since last block processed: ${timeElapsed}ms`);
 
       // If we haven't received a block in 30 seconds, exit so that the process manager can restart us
       if (timeElapsed >= WATCHDOG_KILL_THRESHOLD) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,9 @@ import "dotenv/config";
 import { program, Option } from "@commander-js/extra-typings";
 import { ReplayTxOptions } from "./types";
 import { dumpDb, replayBlock, replayTx, run } from "./commands";
-import { setRootLogLevel } from "./utils";
+import { initLogging } from "./utils";
 
 const logLevelOption = new Option("--log-level <logLevel>", "Log level")
-  .choices(["INFO", "DEBUG", "TRACE", "WARN", "ERROR", "SILENT"] as const)
   .default("INFO")
   .env("LOG_LEVEL");
 
@@ -45,7 +44,7 @@ async function main() {
     .action((options) => {
       const { logLevel } = options;
 
-      setRootLogLevel(logLevel);
+      initLogging({ logLevel });
       const {
         rpc,
         deploymentBlock: deploymentBlockEnv,
@@ -79,6 +78,9 @@ async function main() {
     .requiredOption("--chain-id <chainId>", "Chain ID to dump")
     .addOption(logLevelOption)
     .action((options) => {
+      const { logLevel } = options;
+      initLogging({ logLevel });
+
       // Ensure that the chain ID is a number
       const chainId = Number(options.chainId);
       if (isNaN(chainId)) {
@@ -97,6 +99,9 @@ async function main() {
     .option("--dry-run", "Do not publish orders to the OrderBook API", false)
     .addOption(logLevelOption)
     .action((options) => {
+      const { logLevel } = options;
+      initLogging({ logLevel });
+
       // Ensure that the block is a number
       const block = Number(options.block);
       if (isNaN(block)) {
@@ -113,7 +118,12 @@ async function main() {
     .requiredOption("--tx <tx>", "Transaction hash to replay")
     .option("--dry-run", "Do not publish orders to the OrderBook API", false)
     .addOption(logLevelOption)
-    .action((options: ReplayTxOptions) => replayTx(options));
+    .action((options: ReplayTxOptions) => {
+      const { logLevel } = options;
+      initLogging({ logLevel });
+
+      replayTx(options);
+    });
 
   await program.parseAsync();
 }

--- a/src/utils/logging.ts
+++ b/src/utils/logging.ts
@@ -68,7 +68,7 @@ function setRootLogLevel(level: string) {
 }
 
 function setLogLevel(logLevel = DEFAULT_LOG_LEVEL) {
-  const rootLogLevelDefined = false;
+  let rootLogLevelDefined = false;
 
   // Get the log level overrides
   let logLevelOverrides: LogLevelOverride[];
@@ -82,6 +82,7 @@ function setLogLevel(logLevel = DEFAULT_LOG_LEVEL) {
         if (!loggerDefinition.includes("=")) {
           // If the loggerDefinition does not include a "=" character then it refers to the root logger
           setRootLogLevel(loggerDefinition);
+          rootLogLevelDefined = true;
           return acc;
         }
 


### PR DESCRIPTION
# Description
As pointed out in this comment https://github.com/cowprotocol/infrastructure/pull/746#discussion_r1345243086, it would be simpler if we unify the ENVS that control the logging. 

Before this PR there was 2 independent env vars.

Now, everything is control with `LOG_LEVEL` env. 

To understand how to use it, refer to the README

Example:
```ini
LOG_LEVEL=WARN
```

More complex example:
```ini
LOG_LEVEL="WARN,commands=DEBUG,^checkForAndPlaceOrder=WARN,^chainContext=INFO,_checkForAndPlaceOrder:1:=INFO" yarn ts-node ./src/index.ts
```