### PR TITLE
Add auto deploy

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,3 +33,11 @@ jobs:
           push: true
           tags: ${{ steps.image_meta.outputs.tags }}
           labels: ${{ steps.image_meta.outputs.labels }}
+
+      - uses: cowprotocol/autodeploy-action@v1
+        if: ${{ github.ref == 'refs/heads/main' }}
+        with:
+          images: ghcr.io/cowprotocol/watch-tower:main
+          tag: ${{ secrets.AUTODEPLOY_TAG }}
+          url: ${{ secrets.AUTODEPLOY_URL }}
+          token: ${{ secrets.AUTODEPLOY_TOKEN }}


### PR DESCRIPTION
# Description
The auto-deploy process requires a couple of secrets that have already been configured in this repository. If we are not changing the namespace, there is no need to deploy another pod for auto-deploy as it is already deployed on the staging cluster for the `services` namespace.

The action hits the auto-deploy URL with credentials to restart all pods using the specified image.

Resolves #79 
