### PR TITLE
fix: drop incompatible orders

### DIFF
--- a/src/domain/checkForAndPlaceOrder.ts
+++ b/src/domain/checkForAndPlaceOrder.ts
@@ -10,7 +10,6 @@ import { BytesLike } from "ethers/lib/utils";
 
 import { ConditionalOrder, OrderStatus } from "../types";
 import {
-  LowLevelError,
   formatStatus,
   getLogger,
   pollConditionalOrder,
@@ -511,6 +510,8 @@ async function _pollLegacy(
   orderRef: string
 ): Promise<PollResult> {
   const { contract, multicall } = context;
+  const logPrefix = `checkForAndPlaceOrder:_pollLegacy:${orderRef}`;
+  const log = getLogger(logPrefix);
   // as we going to use multicall, with `aggregate3Value`, there is no need to do any simulation as the
   // calls are guaranteed to pass, and will return the results, or the reversion within the ABI-encoded data.
   // By not using `populateTransaction`, we avoid an `eth_estimateGas` RPC call.
@@ -532,164 +533,155 @@ async function _pollLegacy(
 
     const [{ success, returnData }] = lowLevelCall;
 
-    // If the call failed, there may be a custom error to provide hints. We wrap the error in a LowLevelError
-    // so that it can be handled in the catch.
-    if (!success) {
-      throw new LowLevelError("low-level call failed", returnData);
+    if (success) {
+      // Decode the result to get the order and signature
+      const { order, signature } = contract.interface.decodeFunctionResult(
+        "getTradeableOrderWithSignature",
+        returnData
+      );
+      return {
+        result: PollResultCode.SUCCESS,
+        order,
+        signature,
+      };
     }
 
-    // Decode the result to get the order and signature
-    const { order, signature } = contract.interface.decodeFunctionResult(
-      "getTradeableOrderWithSignature",
-      returnData
-    );
-    return {
-      result: PollResultCode.SUCCESS,
-      order,
-      signature,
-    };
-  } catch (error: any) {
-    // An error of some type occurred. It may or may not be a hint. We pass it to the handler to decide.
-    return _handleGetTradableOrderWithSignatureCall(
-      error,
+    // If the call failed, there may be a custom error to provide hints. Let's try.
+    return _handleOnChainCustomError(
       owner,
       orderRef,
       context,
       to,
-      data
+      data,
+      returnData
     );
+  } catch (error: any) {
+    log.error(`${logPrefix} ethers/call Unexpected error`, error);
+    // We can only get here from some provider / ethers failure. As the contract hasn't had it's say
+    // we will defer to try again.
+    // TODO: Add metrics to track this
+    return {
+      result: PollResultCode.TRY_NEXT_BLOCK,
+      reason:
+        "UnexpectedErrorName: Unexpected error" +
+        (error.message ? `: ${error.message}` : ""),
+    };
   }
 }
 
-function _handleGetTradableOrderWithSignatureCall(
-  error: any,
+function _handleOnChainCustomError(
   owner: string,
   orderRef: string,
   context: ChainContext,
   to: string,
-  data: string
+  data: string,
+  returnData: string
 ): PollResultErrors {
-  const logPrefix = `checkForAndPlaceOrder:_handleGetTradableOrderCall:${orderRef}`;
+  const logPrefix = `checkForAndPlaceOrder:_handleOnChainCustomError:${orderRef}`;
   const log = getLogger(logPrefix);
   const { chainId } = context;
 
-  // If the error is a LowLevelError, we extract the selector, and any parameters.
-  if (error instanceof LowLevelError) {
-    try {
-      // The below will throw if:
-      // - the error is not a custom error (ie. the selector is not in the map)
-      // - the error is a custom error, but the parameters are not as expected
-      const { selector, message, blockNumberOrEpoch } = customErrorDecode(
-        error.data
-      );
-      switch (selector) {
-        case "SINGLE_ORDER_NOT_AUTHED":
-        case "PROOF_NOT_AUTHED":
-          // If there's no authorization we delete the order
-          // - One reason could be, because the user CANCELLED the order
-          // - for now it doesn't support more advanced cases where the order is auth during a pre-interaction
-          log.info(
-            `${selector}: Order on safe ${owner} not authed. Deleting order...`
-          );
-          return {
-            result: PollResultCode.DONT_TRY_AGAIN,
-            reason: `${selector}: The owner has not authorized the order`,
-          };
-        case "INTERFACE_NOT_SUPPORTED":
-          log.info(
-            `${selector}: Order on safe ${owner} attempted to use a handler that is not supported. Deleting order...`
-          );
-          return {
-            result: PollResultCode.DONT_TRY_AGAIN,
-            reason: `${selector}: The handler is not supported`,
-          };
-        case "INVALID_FALLBACK_HANDLER":
-          log.info(
-            `${selector}: Order for safe ${owner} where the Safe does not have ExtensibleFallbackHandler set. Deleting order...`
-          );
-          return {
-            result: PollResultCode.DONT_TRY_AGAIN,
-            reason: `${selector}: The safe does not have ExtensibleFallbackHandler set`,
-          };
-        case "SWAP_GUARD_RESTRICTED":
-          log.info(
-            `${selector}: Order for safe ${owner} where the Safe has swap guard enabled. Deleting order...`
-          );
-          return {
-            result: PollResultCode.DONT_TRY_AGAIN,
-            reason: `${selector}: The safe has swap guard enabled`,
-          };
-        // TODO: Add metrics to track this
-        case "ORDER_NOT_VALID":
-        case "POLL_TRY_NEXT_BLOCK":
-          // OrderNotValid: With the revised custom errors, `OrderNotValid` is generally returned when elements
-          // of the data struct are invalid. For example, if the `sellAmount` is zero, or the `validTo` is in
-          // the past.
-          // PollTryNextBlock: The conditional order has signalled that it should be polled again on the next block.
-          log.info(
-            `${selector}: Order on safe ${owner} not valid/signalled to try next block.`
-          );
-          return {
-            result: PollResultCode.TRY_NEXT_BLOCK,
-            reason: `${selector}: ${message}`,
-          };
-        case "POLL_TRY_AT_BLOCK":
-          // The conditional order has signalled that it should be polled again on a specific block.
-          if (!blockNumberOrEpoch) {
-            throw new Error(
-              `Expected blockNumberOrEpoch to be defined for ${selector}`
-            );
-          }
-          return {
-            result: PollResultCode.TRY_ON_BLOCK,
-            blockNumber: blockNumberOrEpoch,
-            reason: `PollTryAtBlock: ${message}`,
-          };
-        case "POLL_TRY_AT_EPOCH":
-          // The conditional order has signalled that it should be polled again on a specific epoch.
-          if (!blockNumberOrEpoch) {
-            throw new Error(
-              `Expected blockNumberOrEpoch to be defined for ${selector}`
-            );
-          }
-          return {
-            result: PollResultCode.TRY_AT_EPOCH,
-            epoch: blockNumberOrEpoch,
-            reason: `PollTryAtEpoch: ${message}`,
-          };
-        case "POLL_NEVER":
-          // The conditional order has signalled that it should never be polled again.
-          return {
-            result: PollResultCode.DONT_TRY_AGAIN,
-            reason: `PollNever: ${message}`,
-          };
-      }
-    } catch (err: any) {
-      // Any errors thrown here can _ONLY_ come from non-compliant interfaces (ie. bad revert ABI encoding).
-      // We log the error, and return a DONT_TRY_AGAIN result.
+  try {
+    // The below will throw if:
+    // - the error is not a custom error (ie. the selector is not in the map)
+    // - the error is a custom error, but the parameters are not as expected
+    const { selector, message, blockNumberOrEpoch } =
+      customErrorDecode(returnData);
+    switch (selector) {
+      case "SINGLE_ORDER_NOT_AUTHED":
+      case "PROOF_NOT_AUTHED":
+        // If there's no authorization we delete the order
+        // - One reason could be, because the user CANCELLED the order
+        // - for now it doesn't support more advanced cases where the order is auth during a pre-interaction
+        log.info(
+          `${selector}: Order on safe ${owner} not authed. Deleting order...`
+        );
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `${selector}: The owner has not authorized the order`,
+        };
+      case "INTERFACE_NOT_SUPPORTED":
+        log.info(
+          `${selector}: Order on safe ${owner} attempted to use a handler that is not supported. Deleting order...`
+        );
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `${selector}: The handler is not supported`,
+        };
+      case "INVALID_FALLBACK_HANDLER":
+        log.info(
+          `${selector}: Order for safe ${owner} where the Safe does not have ExtensibleFallbackHandler set. Deleting order...`
+        );
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `${selector}: The safe does not have ExtensibleFallbackHandler set`,
+        };
+      case "SWAP_GUARD_RESTRICTED":
+        log.info(
+          `${selector}: Order for safe ${owner} where the Safe has swap guard enabled. Deleting order...`
+        );
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `${selector}: The safe has swap guard enabled`,
+        };
       // TODO: Add metrics to track this
-      log.error(
-        `Contract returned non-interface compliant revert via getTradeableOrderWithSignature. Simulate: https://dashboard.tenderly.co/gp-v2/watch-tower-prod/simulator/new?network=${chainId}&contractAddress=${to}&rawFunctionInput=${data}`
-      );
-      return {
-        result: PollResultCode.DONT_TRY_AGAIN,
-        reason:
-          "Non-compliant interface error" +
-          (err.message ? `: ${err.message}` : ""),
-      };
+      case "ORDER_NOT_VALID":
+      case "POLL_TRY_NEXT_BLOCK":
+        // OrderNotValid: With the revised custom errors, `OrderNotValid` is generally returned when elements
+        // of the data struct are invalid. For example, if the `sellAmount` is zero, or the `validTo` is in
+        // the past.
+        // PollTryNextBlock: The conditional order has signalled that it should be polled again on the next block.
+        log.info(
+          `${selector}: Order on safe ${owner} not valid/signalled to try next block.`
+        );
+        return {
+          result: PollResultCode.TRY_NEXT_BLOCK,
+          reason: `${selector}: ${message}`,
+        };
+      case "POLL_TRY_AT_BLOCK":
+        // The conditional order has signalled that it should be polled again on a specific block.
+        if (!blockNumberOrEpoch) {
+          throw new Error(
+            `Expected blockNumberOrEpoch to be defined for ${selector}`
+          );
+        }
+        return {
+          result: PollResultCode.TRY_ON_BLOCK,
+          blockNumber: blockNumberOrEpoch,
+          reason: `PollTryAtBlock: ${message}`,
+        };
+      case "POLL_TRY_AT_EPOCH":
+        // The conditional order has signalled that it should be polled again on a specific epoch.
+        if (!blockNumberOrEpoch) {
+          throw new Error(
+            `Expected blockNumberOrEpoch to be defined for ${selector}`
+          );
+        }
+        return {
+          result: PollResultCode.TRY_AT_EPOCH,
+          epoch: blockNumberOrEpoch,
+          reason: `PollTryAtEpoch: ${message}`,
+        };
+      case "POLL_NEVER":
+        // The conditional order has signalled that it should never be polled again.
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `PollNever: ${message}`,
+        };
     }
+  } finally {
+    // We use finally here to ensure that we always log the error, even if we hit an unexpected error
+    // Any errors thrown here can _ONLY_ come from non-compliant interfaces (ie. bad revert ABI encoding).
+    // We log the error, and return a DONT_TRY_AGAIN result.
+    // TODO: Add metrics to track this
+    log.debug(
+      `Contract returned non-interface compliant revert via getTradeableOrderWithSignature. Simulate: https://dashboard.tenderly.co/gp-v2/watch-tower-prod/simulator/new?network=${chainId}&contractAddress=${to}&rawFunctionInput=${data}`
+    );
+    return {
+      result: PollResultCode.DONT_TRY_AGAIN,
+      reason: "Non-compliant interface",
+    };
   }
-
-  log.error(`${logPrefix} ethers/call Unexpected error`, error);
-  // We can only get here from some provider / ethers failure. As the contract hasn't had it's say
-  // we will defer to try again.
-  // TODO: Add metrics to track this
-  return {
-    result: PollResultCode.TRY_NEXT_BLOCK,
-    reason:
-      "UnexpectedErrorName: Unexpected error" +
-      (error.message ? `: ${error.message}` : ""),
-  };
 }
 
 /**

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -2,8 +2,12 @@ import { ethers } from "ethers";
 import { ComposableCoW, ComposableCoW__factory } from "../types";
 import {
   COMPOSABLE_COW_CONTRACT_ADDRESS,
+  MAX_UINT32,
+  PollResultCode,
+  PollResultErrors,
   SupportedChainId,
 } from "@cowprotocol/cow-sdk";
+import { getLogger } from "./logging";
 
 // Selectors that are required to be part of the contract's bytecode in order to be considered compatible
 const REQUIRED_SELECTORS = [
@@ -11,32 +15,47 @@ const REQUIRED_SELECTORS = [
   "getTradeableOrderWithSignature(address,(address,bytes32,bytes),bytes,bytes32[])",
 ];
 
-const CUSTOM_ERROR_ABI_MAP = {
-  PROOF_NOT_AUTHED: "ProofNotAuthed()",
-  SINGLE_ORDER_NOT_AUTHED: "SingleOrderNotAuthed()",
-  SWAP_GUARD_RESTRICTED: "SwapGuardRestricted()",
-  INVALID_HANDLER: "InvalidHandler()",
-  INVALID_FALLBACK_HANDLER: "InvalidFallbackHandler()",
-  INTERFACE_NOT_SUPPORTED: "InterfaceNotSupported()",
-  ORDER_NOT_VALID: "OrderNotValid(string)",
-  POLL_TRY_NEXT_BLOCK: "PollTryNextBlock(string)",
-  POLL_NEVER: "PollNever(string)",
-  POLL_TRY_AT_BLOCK: "PollTryAtBlock(uint256,string)",
-  POLL_TRY_AT_EPOCH: "PollTryAtEpoch(uint256,string)",
+// Define an enum for the custom errors that can be returned by the ComposableCoW contract
+export enum CustomErrorSelectors {
+  PROOF_NOT_AUTHED = "PROOF_NOT_AUTHED",
+  SINGLE_ORDER_NOT_AUTHED = "SINGLE_ORDER_NOT_AUTHED",
+  SWAP_GUARD_RESTRICTED = "SWAP_GUARD_RESTRICTED",
+  INVALID_HANDLER = "INVALID_HANDLER",
+  INVALID_FALLBACK_HANDLER = "INVALID_FALLBACK_HANDLER",
+  INTERFACE_NOT_SUPPORTED = "INTERFACE_NOT_SUPPORTED",
+  ORDER_NOT_VALID = "ORDER_NOT_VALID",
+  POLL_TRY_NEXT_BLOCK = "POLL_TRY_NEXT_BLOCK",
+  POLL_NEVER = "POLL_NEVER",
+  POLL_TRY_AT_BLOCK = "POLL_TRY_AT_BLOCK",
+  POLL_TRY_AT_EPOCH = "POLL_TRY_AT_EPOCH",
+}
+
+export const CUSTOM_ERROR_ABI_MAP: Record<CustomErrorSelectors, string> = {
+  [CustomErrorSelectors.PROOF_NOT_AUTHED]: "ProofNotAuthed()",
+  [CustomErrorSelectors.SINGLE_ORDER_NOT_AUTHED]: "SingleOrderNotAuthed()",
+  [CustomErrorSelectors.SWAP_GUARD_RESTRICTED]: "SwapGuardRestricted()",
+  [CustomErrorSelectors.INVALID_HANDLER]: "InvalidHandler()",
+  [CustomErrorSelectors.INVALID_FALLBACK_HANDLER]: "InvalidFallbackHandler()",
+  [CustomErrorSelectors.INTERFACE_NOT_SUPPORTED]: "InterfaceNotSupported()",
+  [CustomErrorSelectors.ORDER_NOT_VALID]: "OrderNotValid(string)",
+  [CustomErrorSelectors.POLL_TRY_NEXT_BLOCK]: "PollTryNextBlock(string)",
+  [CustomErrorSelectors.POLL_NEVER]: "PollNever(string)",
+  [CustomErrorSelectors.POLL_TRY_AT_BLOCK]: "PollTryAtBlock(uint256,string)",
+  [CustomErrorSelectors.POLL_TRY_AT_EPOCH]: "PollTryAtEpoch(uint256,string)",
 };
 
-// Just export the keys of the CUSTOM_ERROR_ABI_MAP as a type
-export type CustomError = keyof typeof CUSTOM_ERROR_ABI_MAP;
+// Process the CUSTOM_ERROR_ABI_MAP to change the values to the ABI-encoded selectors
+const CUSTOM_ERROR_SELECTOR_MAP: Record<string, CustomErrorSelectors> = {};
 
-// To be able to do fast lookup of the selector given the id, we need to reverse the map
-// This should be a one-time operation, and cached for future use
-const CUSTOM_ERROR_ID_TO_NAME_MAP = Object.entries(CUSTOM_ERROR_ABI_MAP).reduce(
-  (acc, [name, selector]) => {
-    acc[ethers.utils.id(selector).slice(0, 10)] = name as CustomError;
-    return acc;
-  },
-  {} as Record<string, CustomError>
-);
+export const abiToSelector = (abi: string): string =>
+  ethers.utils.id(abi).slice(0, 10);
+
+for (const errorType of Object.keys(
+  CUSTOM_ERROR_ABI_MAP
+) as CustomErrorSelectors[]) {
+  const selector = abiToSelector(CUSTOM_ERROR_ABI_MAP[errorType]);
+  CUSTOM_ERROR_SELECTOR_MAP[selector] = errorType;
+}
 
 /**
  * Attempts to verify that the contract at the given address implements the interface of the `ComposableCoW`
@@ -72,64 +91,201 @@ export function composableCowContract(
   );
 }
 
-type ParsedError = {
-  selector: string;
+type ParsedCustomError = {
+  selector: CustomErrorSelectors;
   message?: string;
   blockNumberOrEpoch?: number;
 };
 
 /**
  * Given a raw ABI-encoded custom error returned from a revert, extract the selector and optionally a message.
- * @param errorData ABI-encoded custom error, which may or may not be parameterized.
+ * @param revertData ABI-encoded custom error, which may or may not be parameterized.
  * @returns an empty parsed error if assumptions don't hold, otherwise the selector and message if applicable.
  */
-export function customErrorDecode(errorData: string): ParsedError {
-  // only proceed if the return data is at least 10 bytes long
-  if (errorData.length >= 10) {
-    const rawSelector = errorData.slice(0, 10);
-    // if the raw selector is not in the map, break early
-    if (!(rawSelector in CUSTOM_ERROR_ID_TO_NAME_MAP)) {
-      return { selector: rawSelector, message: `Unknown error: ${errorData}` };
+export function parseCustomError(revertData: string): ParsedCustomError {
+  try {
+    // If the revert data is not at least 4 bytes long (8 hex characters, 0x prefixed), it cannot contain a selector
+    if (revertData.length < 10) {
+      throw new Error("Revert data too short to contain a selector");
     }
 
-    const selector = CUSTOM_ERROR_ID_TO_NAME_MAP[errorData.slice(0, 10)];
-    try {
-      switch (selector) {
-        case "PROOF_NOT_AUTHED":
-        case "SINGLE_ORDER_NOT_AUTHED":
-        case "INTERFACE_NOT_SUPPORTED":
-        case "INVALID_FALLBACK_HANDLER":
-        case "INVALID_HANDLER":
-        case "SWAP_GUARD_RESTRICTED":
-          return { selector };
-        case "ORDER_NOT_VALID":
-        case "POLL_TRY_NEXT_BLOCK":
-        case "POLL_NEVER":
-          const message = ethers.utils.defaultAbiCoder.decode(
-            ["string"],
-            "0x" + errorData.slice(10) // trim off the selector
-          )[0];
-          return { selector, message };
-        case "POLL_TRY_AT_BLOCK":
-        case "POLL_TRY_AT_EPOCH":
-          const [blockNumberOrEpoch, msg] = ethers.utils.defaultAbiCoder.decode(
-            ["uint256", "string"],
-            "0x" + errorData.slice(10) // trim off the selector
-          );
-          return {
-            selector,
-            message: msg,
-            blockNumberOrEpoch: blockNumberOrEpoch.toNumber(),
-          };
-      }
-    } catch (err) {
-      // This can only return an error if the ABI decoding fails, which should never happen
-      // except for a bug in the smart contract code or the ABI encoding. In this case, we
-      // just bubble up the error.
-      throw err;
+    const rawSelector = revertData.slice(0, 10);
+
+    // If the revert data does not contain a selector from the CUSTOM_ERROR_SELECTOR_MAP, it is a non-compliant
+    // interface and we should signal to drop it.
+    if (!(revertData.slice(0, 10) in CUSTOM_ERROR_SELECTOR_MAP)) {
+      throw new Error(
+        "On-chain hint / custom error not compliant with ComposableCoW interface"
+      );
     }
+
+    const selector = CUSTOM_ERROR_SELECTOR_MAP[rawSelector];
+    const fragment = ethers.utils.Fragment.fromString(
+      "error " + CUSTOM_ERROR_ABI_MAP[selector]
+    );
+    const iface = new ethers.utils.Interface([fragment]);
+
+    switch (selector) {
+      case CustomErrorSelectors.PROOF_NOT_AUTHED:
+      case CustomErrorSelectors.SINGLE_ORDER_NOT_AUTHED:
+      case CustomErrorSelectors.INTERFACE_NOT_SUPPORTED:
+      case CustomErrorSelectors.INVALID_FALLBACK_HANDLER:
+      case CustomErrorSelectors.INVALID_HANDLER:
+      case CustomErrorSelectors.SWAP_GUARD_RESTRICTED:
+        return { selector };
+      case CustomErrorSelectors.ORDER_NOT_VALID:
+      case CustomErrorSelectors.POLL_TRY_NEXT_BLOCK:
+      case CustomErrorSelectors.POLL_NEVER:
+        const [message] = iface.decodeErrorResult(fragment, revertData);
+        return { selector, message };
+      case CustomErrorSelectors.POLL_TRY_AT_BLOCK:
+      case CustomErrorSelectors.POLL_TRY_AT_EPOCH:
+        const [blockNumberOrEpoch, msg] = iface.decodeErrorResult(
+          fragment,
+          revertData
+        );
+
+        // It is reasonable to expect that the block number or epoch is bound by
+        // uint32. It is therefore safe to throw if the value is outside of that
+        // for javascript's number type.
+        if (blockNumberOrEpoch.gt(MAX_UINT32)) {
+          throw new Error("Block number or epoch out of bounds");
+        }
+
+        return {
+          selector,
+          message: msg,
+          blockNumberOrEpoch: blockNumberOrEpoch.toNumber(),
+        };
+    }
+  } catch (err) {
+    // This can only throw under the following conditions:
+    // - The revert data is too short to contain a selector
+    // - The revert data contains a selector that is not in the CUSTOM_ERROR_SELECTOR_MAP
+    // - The revert data contains a selector that is in the CUSTOM_ERROR_SELECTOR_MAP, but the
+    //   it's parameters are not ABI-encoded correctly (decode throws)
+    throw err;
   }
+}
 
-  // If we get here, we have a selector that is not in the map, or the return data is too short
-  throw new Error(`Invalid error data: ${errorData}`);
+export function handleOnChainCustomError(params: {
+  owner: string;
+  orderRef: string;
+  chainId: SupportedChainId;
+  target: string;
+  callData: string;
+  revertData: string;
+}): PollResultErrors {
+  const { owner, orderRef, chainId, target, callData, revertData } = params;
+  const logPrefix = `contracts:handleOnChainCustomError:${orderRef}`;
+  const log = getLogger(logPrefix);
+
+  try {
+    // The below will throw if:
+    // - the error is not a custom error (ie. the selector is not in the map)
+    // - the error is a custom error, but the parameters are not as expected
+    const { selector, message, blockNumberOrEpoch } =
+      parseCustomError(revertData);
+    switch (selector) {
+      case CustomErrorSelectors.SINGLE_ORDER_NOT_AUTHED:
+      case CustomErrorSelectors.PROOF_NOT_AUTHED:
+        // If there's no authorization we delete the order
+        // - One reason could be, because the user CANCELLED the order
+        // - for now it doesn't support more advanced cases where the order is auth during a pre-interaction
+        log.info(
+          `${selector}: Order on safe ${owner} not authed. Deleting order...`
+        );
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `${selector}: The owner has not authorized the order`,
+        };
+      case CustomErrorSelectors.INTERFACE_NOT_SUPPORTED:
+        log.info(
+          `${selector}: Order on safe ${owner} attempted to use a handler that is not supported. Deleting order...`
+        );
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `${selector}: The handler is not supported`,
+        };
+      case CustomErrorSelectors.INVALID_FALLBACK_HANDLER:
+        log.info(
+          `${selector}: Order for safe ${owner} where the Safe does not have ExtensibleFallbackHandler set. Deleting order...`
+        );
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `${selector}: The safe does not have ExtensibleFallbackHandler set`,
+        };
+      case CustomErrorSelectors.INVALID_HANDLER:
+        log.info(
+          `${selector}: Order type for safe ${owner}, failed IERC165 introspection check. Deleting order...`
+        );
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `${selector}: The safe does not have the handler set`,
+        };
+      case CustomErrorSelectors.SWAP_GUARD_RESTRICTED:
+        log.info(
+          `${selector}: Order for safe ${owner} where the Safe has swap guard enabled. Deleting order...`
+        );
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `${selector}: The safe has swap guard enabled`,
+        };
+      // TODO: Add metrics to track this
+      case CustomErrorSelectors.ORDER_NOT_VALID:
+      case CustomErrorSelectors.POLL_TRY_NEXT_BLOCK:
+        // OrderNotValid: With the revised custom errors, `OrderNotValid` is generally returned when elements
+        // of the data struct are invalid. For example, if the `sellAmount` is zero, or the `validTo` is in
+        // the past.
+        // PollTryNextBlock: The conditional order has signalled that it should be polled again on the next block.
+        log.info(
+          `${selector}: Order on safe ${owner} not valid/signalled to try next block.`
+        );
+        return {
+          result: PollResultCode.TRY_NEXT_BLOCK,
+          reason: `${selector}: ${message}`,
+        };
+      case CustomErrorSelectors.POLL_TRY_AT_BLOCK:
+        // The conditional order has signalled that it should be polled again on a specific block.
+        if (!blockNumberOrEpoch) {
+          throw new Error(
+            `Expected blockNumberOrEpoch to be defined for ${selector}`
+          );
+        }
+        return {
+          result: PollResultCode.TRY_ON_BLOCK,
+          blockNumber: blockNumberOrEpoch,
+          reason: `PollTryAtBlock: ${message}`,
+        };
+      case CustomErrorSelectors.POLL_TRY_AT_EPOCH:
+        // The conditional order has signalled that it should be polled again on a specific epoch.
+        if (!blockNumberOrEpoch) {
+          throw new Error(
+            `Expected blockNumberOrEpoch to be defined for ${selector}`
+          );
+        }
+        return {
+          result: PollResultCode.TRY_AT_EPOCH,
+          epoch: blockNumberOrEpoch,
+          reason: `PollTryAtEpoch: ${message}`,
+        };
+      case CustomErrorSelectors.POLL_NEVER:
+        // The conditional order has signalled that it should never be polled again.
+        return {
+          result: PollResultCode.DONT_TRY_AGAIN,
+          reason: `PollNever: ${message}`,
+        };
+    }
+  } catch (err) {
+    // Any errors thrown here can _ONLY_ come from non-compliant interfaces (ie. bad revert ABI encoding).
+    // We log the error, and return a DONT_TRY_AGAIN result.
+    // TODO: Add metrics to track this
+    log.debug(
+      `Contract returned a non-interface compliant revert via getTradeableOrderWithSignature. Simulate: https://dashboard.tenderly.co/gp-v2/watch-tower-prod/simulator/new?network=${chainId}&contractAddress=${target}&rawFunctionInput=${callData}`
+    );
+    return {
+      result: PollResultCode.DONT_TRY_AGAIN,
+      reason: "Order returned a non-compliant (invalid/erroneous) revert hint",
+    };
+  }
 }

--- a/src/utils/contracts.ts
+++ b/src/utils/contracts.ts
@@ -66,16 +66,10 @@ export const CUSTOM_ERROR_ABI_MAP: Record<CustomErrorSelectors, string> = {
 };
 
 // Process the CUSTOM_ERROR_ABI_MAP to change the values to the ABI-encoded selectors
-const CUSTOM_ERROR_SELECTOR_MAP: Record<string, CustomErrorSelectors> = {};
+const CUSTOM_ERROR_SELECTOR_MAP = generateCustomErrorSelectorMap();
 
-export const abiToSelector = (abi: string): string =>
-  ethers.utils.id(abi).slice(0, 10);
-
-for (const errorType of Object.keys(
-  CUSTOM_ERROR_ABI_MAP
-) as CustomErrorSelectors[]) {
-  const selector = abiToSelector(CUSTOM_ERROR_ABI_MAP[errorType]);
-  CUSTOM_ERROR_SELECTOR_MAP[selector] = errorType;
+export function abiToSelector(abi: string) {
+  return ethers.utils.id(abi).slice(0, 10);
 }
 
 /**
@@ -292,4 +286,20 @@ export function handleOnChainCustomError(params: {
       reason: "Order returned a non-compliant (invalid/erroneous) revert hint",
     };
   }
+}
+
+function generateCustomErrorSelectorMap(): Record<
+  string,
+  CustomErrorSelectors
+> {
+  const CUSTOM_ERROR_SELECTOR_MAP: Record<string, CustomErrorSelectors> = {};
+
+  for (const errorType of Object.keys(
+    CUSTOM_ERROR_ABI_MAP
+  ) as CustomErrorSelectors[]) {
+    const selector = abiToSelector(CUSTOM_ERROR_ABI_MAP[errorType]);
+    CUSTOM_ERROR_SELECTOR_MAP[selector] = errorType;
+  }
+
+  return CUSTOM_ERROR_SELECTOR_MAP;
 }

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -11,15 +11,6 @@ export function formatStatus(status: OrderStatus) {
   }
 }
 
-export class LowLevelError extends Error {
-  data: string;
-  constructor(msg: string, data: string) {
-    super(msg);
-    this.data = data;
-    Object.setPrototypeOf(this, LowLevelError.prototype);
-  }
-}
-
 /**
  * Converts the typechain conditional order params to the sdk conditional order params (simpler version of the same thing)
  *


### PR DESCRIPTION
# Description
Currently incompatible orders (where there is a low level reversion that's not expected) are *NOT* deleted. This corrects that.

# Changes

- [x] Drop orders that return non-compatible interface revert messages.

## How to test
1. Sync goerli from genesis and confirm no unexpected errors.

## Related Issues

Fixes #91 