### PR TITLE
chore: health probe

### DIFF
--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -405,7 +405,7 @@ async function processBlock(
   events: ConditionalOrderCreatedEvent[],
   blockNumberOverride?: number,
   blockTimestampOverride?: number
-): Promise<ethers.providers.Block> {
+) {
   const { provider, chainId } = context;
   const timer = processBlockDurationSeconds
     .labels(context.chainId.toString())
@@ -454,8 +454,6 @@ async function processBlock(
   if (hasErrors) {
     throw new Error("Errors found in processing block");
   }
-
-  return block;
 }
 
 function pollContractForEvents(

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -331,7 +331,7 @@ export class ChainContext {
       // sleep for 5 seconds
       await asyncSleep(WATCHDOG_FREQUENCY);
       const now = Math.floor(new Date().getTime() / 1000);
-      const timeElapsed = now - (lastBlockReceived?.timestamp ?? 0);
+      const timeElapsed = now - lastBlockReceived.timestamp;
 
       log.debug(`Time since last block processed: ${timeElapsed}ms`);
 

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -6,7 +6,7 @@ import { getLogger } from "./logging";
 import { DBService } from "./db";
 import { Registry } from "../types";
 import { version, name, description } from "../../package.json";
-import { ChainContext, ChainHealth } from "../domain";
+import { ChainContext } from "../domain";
 
 export class ApiService {
   protected port: number;
@@ -35,20 +35,8 @@ export class ApiService {
       res.send("🐮 Moooo!");
     });
     this.app.get("/health", async (_req: Request, res: Response) => {
-      // Using an iterator, process all the chain contexts, storing the health
-      // in a map, and if any of the contexts are unhealthy, return false
-      const contexts = Object.values(ChainContext.chains) as ChainContext[];
-      const healths = contexts.map((context) => context.health);
-      const healthStatusDict = healths.reduce((acc, health) => {
-        acc[health.chainId] = health;
-        return acc;
-      }, {} as { [chainId: string]: ChainHealth });
-
-      const overallHealth = healths.every((health) => health.isHealthy);
-
-      res
-        .status(overallHealth ? 200 : 500)
-        .send({ overallHealth, ...healthStatusDict });
+      const health = ChainContext.health;
+      res.status(health.overallHealth ? 200 : 503).send(health);
     });
     this.app.use("/api", router);
   }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -6,6 +6,7 @@ import { getLogger } from "./logging";
 import { DBService } from "./db";
 import { Registry } from "../types";
 import { version, name, description } from "../../package.json";
+import { ChainContext, ChainHealth } from "../domain";
 
 export class ApiService {
   protected port: number;
@@ -32,6 +33,22 @@ export class ApiService {
     this.app.use(express.urlencoded({ extended: true }));
     this.app.get("/", (_req: Request, res: Response) => {
       res.send("🐮 Moooo!");
+    });
+    this.app.get("/health", async (_req: Request, res: Response) => {
+      // Using an iterator, process all the chain contexts, storing the health
+      // in a map, and if any of the contexts are unhealthy, return false
+      const contexts = Object.values(ChainContext.chains) as ChainContext[];
+      const healths = contexts.map((context) => context.health);
+      const healthStatusDict = healths.reduce((acc, health) => {
+        acc[health.chainId] = health;
+        return acc;
+      }, {} as { [chainId: string]: ChainHealth });
+
+      const overallHealth = healths.every((health) => health.isHealthy);
+
+      res
+        .status(overallHealth ? 200 : 500)
+        .send({ overallHealth, ...healthStatusDict });
     });
     this.app.use("/api", router);
   }

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -113,3 +113,11 @@ export function sendSlack(message: string): boolean {
   });
   return true;
 }
+
+export function isRunningInKubernetesPod(): boolean {
+  // Check if the standard Kubernetes environment variables are set
+  return (
+    process.env.KUBERNETES_SERVICE_HOST !== undefined &&
+    process.env.KUBERNETES_SERVICE_PORT !== undefined
+  );
+}


### PR DESCRIPTION
# Description
This PR provides overall health monitoring for the block watcher (chain contexts). This assists with Kubernetes deployment to enable health probes for automatic restarting and monitoring.

# Changes

- [x] All chain contexts added to a static mapping for use in other services (ie. API).
- [x] Implemented `/health` API endpoint, returning >= 400 when the chain is not synced (in warm-up).

## How to test

1. Start syncing chain from scratch.
2. Observe the `/health` API endpoint returns `500` status error, with JSON showing current chain context status.
3. Once in sync, observe the `/health` API endpoint returns `200` status with JSON showing the current chain status.

## Related Issues

Fixes #70 