### PR TITLE
feat: add orderbook API base url

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@commander-js/extra-typings": "^11.0.0",
     "@cowprotocol/contracts": "^1.4.0",
-    "@cowprotocol/cow-sdk": "^4.0.0",
+    "@cowprotocol/cow-sdk": "^4.0.3",
     "chalk": "^4.1.2",
     "ethers": "^5.7.2",
     "express": "^4.18.2",

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -36,6 +36,8 @@ const WATCHDOG_FREQUENCY = 5 * 1000; // 5 seconds
 
 const MULTICALL3 = "0xcA11bde05977b3631167028862bE2a173976CA11";
 
+export const SDK_BACKOFF_NUM_OF_ATTEMPTS = 5;
+
 enum ChainSync {
   /** The chain is currently in the warm-up phase, synchronising from contract genesis or lastBlockProcessed */
   SYNCING = "SYNCING",
@@ -107,6 +109,9 @@ export class ChainContext {
     this.orderBook = new OrderBookApi({
       chainId: this.chainId,
       baseUrls: this.orderBookApiBaseUrls,
+      backoffOpts: {
+        numOfAttempts: SDK_BACKOFF_NUM_OF_ATTEMPTS,
+      },
     });
 
     this.contract = composableCowContract(this.provider, this.chainId);

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -9,7 +9,11 @@ import {
   RegistryBlock,
   blockToRegistryBlock,
 } from "../types";
-import { SupportedChainId, OrderBookApi } from "@cowprotocol/cow-sdk";
+import {
+  SupportedChainId,
+  OrderBookApi,
+  ApiBaseUrls,
+} from "@cowprotocol/cow-sdk";
 import { addContract } from "./addContract";
 import { checkForAndPlaceOrder } from "./checkForAndPlaceOrder";
 import { ethers } from "ethers";
@@ -77,12 +81,14 @@ export class ChainContext {
   orderBook: OrderBookApi;
   contract: ComposableCoW;
   multicall: Multicall3;
+  orderBookApiBaseUrls?: ApiBaseUrls;
 
   protected constructor(
     options: RunSingleOptions,
     provider: ethers.providers.Provider,
     chainId: SupportedChainId,
-    registry: Registry
+    registry: Registry,
+    orderBookApi?: string
   ) {
     const { deploymentBlock, pageSize, dryRun } = options;
     this.deploymentBlock = deploymentBlock;
@@ -92,7 +98,16 @@ export class ChainContext {
     this.provider = provider;
     this.chainId = chainId;
     this.registry = registry;
-    this.orderBook = new OrderBookApi({ chainId: this.chainId });
+    this.orderBookApiBaseUrls = orderBookApi
+      ? ({
+          [this.chainId]: orderBookApi,
+        } as ApiBaseUrls) // FIXME: do not do this casting once this is fixed https://github.com/cowprotocol/cow-sdk/issues/176
+      : undefined;
+
+    this.orderBook = new OrderBookApi({
+      chainId: this.chainId,
+      baseUrls: this.orderBookApiBaseUrls,
+    });
 
     this.contract = composableCowContract(this.provider, this.chainId);
     this.multicall = Multicall3__factory.connect(MULTICALL3, this.provider);
@@ -108,7 +123,7 @@ export class ChainContext {
     options: RunSingleOptions,
     storage: DBService
   ): Promise<ChainContext> {
-    const { rpc, deploymentBlock } = options;
+    const { rpc, orderBookApi, deploymentBlock } = options;
 
     const provider = new ethers.providers.JsonRpcProvider(rpc);
     const chainId = (await provider.getNetwork()).chainId;
@@ -120,7 +135,13 @@ export class ChainContext {
     );
 
     // Save the context to the static map to be used by the API
-    const context = new ChainContext(options, provider, chainId, registry);
+    const context = new ChainContext(
+      options,
+      provider,
+      chainId,
+      registry,
+      orderBookApi
+    );
     ChainContext.chains[chainId] = context;
 
     return context;

--- a/src/domain/checkForAndPlaceOrder.ts
+++ b/src/domain/checkForAndPlaceOrder.ts
@@ -236,7 +236,8 @@ async function _processConditionalOrder(
   context: ChainContext,
   orderRef: string
 ): Promise<PollResult> {
-  const { provider, orderBook, dryRun, chainId } = context;
+  const { provider, orderBook, dryRun, chainId, orderBookApiBaseUrls } =
+    context;
   const { handler } = conditionalOrder.params;
   const log = getLogger(
     "checkForAndPlaceOrder:_processConditionalOrder",
@@ -262,6 +263,10 @@ async function _processConditionalOrder(
         blockNumber,
       },
       provider,
+      orderbookApiConfig: {
+        // TODO: Should work after this is merged https://github.com/cowprotocol/cow-sdk/pull/177
+        baseUrls: orderBookApiBaseUrls,
+      },
     };
     let pollResult = await pollConditionalOrder(
       pollParams,

--- a/src/domain/checkForAndPlaceOrder.ts
+++ b/src/domain/checkForAndPlaceOrder.ts
@@ -264,7 +264,6 @@ async function _processConditionalOrder(
       },
       provider,
       orderbookApiConfig: {
-        // TODO: Should work after this is merged https://github.com/cowprotocol/cow-sdk/pull/177
         baseUrls: orderBookApiBaseUrls,
         backoffOpts: {
           numOfAttempts: SDK_BACKOFF_NUM_OF_ATTEMPTS,

--- a/src/domain/checkForAndPlaceOrder.ts
+++ b/src/domain/checkForAndPlaceOrder.ts
@@ -28,7 +28,7 @@ import {
   SupportedChainId,
   formatEpoch,
 } from "@cowprotocol/cow-sdk";
-import { ChainContext } from "./chainContext";
+import { ChainContext, SDK_BACKOFF_NUM_OF_ATTEMPTS } from "./chainContext";
 import {
   pollingOnChainDurationSeconds,
   activeOrdersTotal,
@@ -266,6 +266,9 @@ async function _processConditionalOrder(
       orderbookApiConfig: {
         // TODO: Should work after this is merged https://github.com/cowprotocol/cow-sdk/pull/177
         baseUrls: orderBookApiBaseUrls,
+        backoffOpts: {
+          numOfAttempts: SDK_BACKOFF_NUM_OF_ATTEMPTS,
+        },
       },
     };
     let pollResult = await pollConditionalOrder(

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,6 +210,7 @@ async function main() {
         ...options,
         rpcs,
         deploymentBlocks,
+        orderBookApis,
         pageSize,
         apiPort,
         watchdogTimeout,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,6 +23,7 @@ export interface RunOptions extends WatchtowerOptions {
 
 export interface RunSingleOptions extends RunOptions {
   rpc: string;
+  orderBookApi?: string;
   deploymentBlock: number;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,6 +30,7 @@ export interface RunSingleOptions extends RunOptions {
 export interface RunMultiOptions extends RunOptions {
   rpcs: string[];
   deploymentBlocks: number[];
+  orderBookApis: string[];
 }
 
 export interface ReplayBlockOptions extends WatchtowerReplayOptions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -466,10 +466,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.4.0.tgz#e93e5f25aac76feeaa348fa57231903274676247"
   integrity sha512-XLs3SlPmXD4lbiWIO7mxxuCn1eE5isuO6EUlE1cj17HqN/wukDAN0xXYPx6umOH/XdjGS33miMiPHELEyY9siw==
 
-"@cowprotocol/cow-sdk@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-4.0.0.tgz#5b81bea462206719d9d02180a341dd905cb77573"
-  integrity sha512-bJvR//XkEJngxbDedOCahDnawwCG/yKn1jwe+3eiQwSqoJx3gvimP/ahNW9BstMvJZ96Pen0xKrBg0BiJA55lA==
+"@cowprotocol/cow-sdk@^4.0.3":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-4.0.3.tgz#bd4da3e1821c33e6f5a29e04786aaa16c346bb02"
+  integrity sha512-bEGpHwfFpUv4he5kH99gmmJU1kZaqRH4JUCeFqIzZAxey86i+qLzVS00r3GDw5o/tKYY/0677hgusH2srr8MZw==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
# Description
Allow to set your own Orderbook API URL instead of the default ones from the SDK.

This PR is a follow up on https://github.com/cowprotocol/cow-sdk/pull/177.

The motivation, is to allow to set our service IP instead of the external one, to make the connection more performant.

## Bonus
While testing this, i realized that in case of an error, the SDK re-attempts 10 times using exponential backoff. This makes it take too much time in case of an error. I reduced to 5 the attempts, and now it re-attempts, but it will take at most a few seconds instead of 2-3 minutes.

## Follow up
After this is merged, we will need to set it up (please, let me do it!) 

See
https://cowservices.slack.com/archives/C05RMJB7ZFA/p1697021044757619?thread_ts=1697007472.259279&cid=C05RMJB7ZFA

## Test
Pass the `--orderBookApi ` and make sure it uses the parameter

```bash
ts-node ./src/index.ts run --rpc <your-rpc> --dployment-block 9847564 --page-size 5000 --orderBookApi https://api.cow.fi/goerli
```

Once this is in staging we can test this in the infrastructure project.