### PR TITLE
feat: single chain

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,4 +1,5 @@
 export * from "./run";
+export * from "./runMulti";
 export * from "./replayBlock";
 export * from "./replayTx";
 export * from "./dumpDb";

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -1,5 +1,5 @@
 import {
-  SingularRunOptions,
+  RunSingleOptions,
   Registry,
   ReplayPlan,
   ConditionalOrderCreatedEvent,
@@ -79,7 +79,7 @@ export class ChainContext {
   multicall: Multicall3;
 
   protected constructor(
-    options: SingularRunOptions,
+    options: RunSingleOptions,
     provider: ethers.providers.Provider,
     chainId: SupportedChainId,
     registry: Registry
@@ -105,7 +105,7 @@ export class ChainContext {
    * @returns A chain context that is monitoring for orders on the chain.
    */
   public static async init(
-    options: SingularRunOptions,
+    options: RunSingleOptions,
     storage: DBService
   ): Promise<ChainContext> {
     const { rpc, deploymentBlock } = options;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,8 @@ import { dumpDb, replayBlock, replayTx, run, runMulti } from "./commands";
 import { initLogging } from "./utils";
 import { version, description } from "../package.json";
 
+const DEFAULT_DATABASE_PATH = "./database";
+
 const logLevelOption = new Option("--log-level <logLevel>", "Log level")
   .default("INFO")
   .env("LOG_LEVEL");
@@ -19,6 +21,7 @@ const pageSizeOption = new Option(
   "Number of historical blocks to fetch per page from eth_getLogs"
 )
   .default("5000")
+  .env("PAGE_SIZE")
   .argParser(parseIntOption);
 
 const disableNotificationsOption = new Option(
@@ -26,56 +29,63 @@ const disableNotificationsOption = new Option(
   "Disable notifications (local logging only)"
 )
   .conflicts(["slackWebhook"])
-  .default(false);
+  .default(false)
+  .env("DISABLE_NOTIFICATIONS");
 
 const dryRunOnlyOption = new Option(
   "--dry-run",
   "Do not publish orders to the OrderBook API"
-).default(false);
+)
+  .default(false)
+  .env("DRY_RUN");
 
-const disableApiOption = new Option(
-  "--disable-api",
-  "Disable the REST API"
-).default(false);
+const disableApiOption = new Option("--disable-api", "Disable the REST API")
+  .default(false)
+  .env("DISABLE_API");
 
 const apiPortOption = new Option(
   "--api-port <apiPort>",
   "Port for the REST API"
 )
   .default("8080")
+  .env("API_PORT")
   .argParser(parseIntOption);
 
 const oneShotOption = new Option(
   "--one-shot",
   "Run the watch-tower once and exit"
-).default(false);
+)
+  .default(false)
+  .env("ONE_SHOT");
 
 const slackWebhookOption = new Option(
   "--slack-webhook <slackWebhook>",
   "Slack webhook URL"
-);
+).env("SLACK_WEBHOOK");
 
 const watchdogTimeoutOption = new Option(
   "--watchdog-timeout <watchdogTimeout>",
   "Watchdog timeout (in seconds)"
 )
   .default("30")
+  .env("WATCHDOG_TIMEOUT")
   .argParser(parseIntOption);
 
 const databasePathOption = new Option(
   "--database-path <databasePath>",
   "Path to the database"
-).default("./database");
+)
+  .default(DEFAULT_DATABASE_PATH)
+  .env("DATABASE_PATH");
 
 const multiRpcOption = new Option(
   "--rpc <rpc...>",
   "Chain RPC endpoints to monitor"
 ).makeOptionMandatory(true);
 
-const rpcOption = new Option(
-  "--rpc <rpc>",
-  "Chain RPC endpoint to monitor"
-).makeOptionMandatory(true);
+const rpcOption = new Option("--rpc <rpc>", "Chain RPC endpoint to monitor")
+  .makeOptionMandatory(true)
+  .env("RPC");
 
 const multiDeploymentBlockOption = new Option(
   "--deployment-block <deploymentBlocks...>",
@@ -87,6 +97,7 @@ const deploymentBlockOption = new Option(
   "Block number at which the ComposableCoW was deployed"
 )
   .makeOptionMandatory(true)
+  .env("DEPLOYMENT_BLOCK")
   .argParser(parseIntOption);
 
 async function main() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   InvalidArgumentError,
 } from "@commander-js/extra-typings";
 import { ReplayTxOptions } from "./types";
-import { dumpDb, replayBlock, replayTx, run } from "./commands";
+import { dumpDb, replayBlock, replayTx, run, runMulti } from "./commands";
 import { initLogging } from "./utils";
 import { version, description } from "../package.json";
 
@@ -14,54 +14,133 @@ const logLevelOption = new Option("--log-level <logLevel>", "Log level")
   .default("INFO")
   .env("LOG_LEVEL");
 
+const pageSizeOption = new Option(
+  "--page-size <pageSize>",
+  "Number of historical blocks to fetch per page from eth_getLogs"
+)
+  .default("5000")
+  .argParser(parseIntOption);
+
+const disableNotificationsOption = new Option(
+  "--silent",
+  "Disable notifications (local logging only)"
+)
+  .conflicts(["slackWebhook"])
+  .default(false);
+
+const dryRunOnlyOption = new Option(
+  "--dry-run",
+  "Do not publish orders to the OrderBook API"
+).default(false);
+
+const disableApiOption = new Option(
+  "--disable-api",
+  "Disable the REST API"
+).default(false);
+
+const apiPortOption = new Option(
+  "--api-port <apiPort>",
+  "Port for the REST API"
+)
+  .default("8080")
+  .argParser(parseIntOption);
+
+const oneShotOption = new Option(
+  "--one-shot",
+  "Run the watch-tower once and exit"
+).default(false);
+
+const slackWebhookOption = new Option(
+  "--slack-webhook <slackWebhook>",
+  "Slack webhook URL"
+);
+
+const watchdogTimeoutOption = new Option(
+  "--watchdog-timeout <watchdogTimeout>",
+  "Watchdog timeout (in seconds)"
+)
+  .default("30")
+  .argParser(parseIntOption);
+
+const databasePathOption = new Option(
+  "--database-path <databasePath>",
+  "Path to the database"
+).default("./database");
+
+const multiRpcOption = new Option(
+  "--rpc <rpc...>",
+  "Chain RPC endpoints to monitor"
+).makeOptionMandatory(true);
+
+const rpcOption = new Option(
+  "--rpc <rpc>",
+  "Chain RPC endpoint to monitor"
+).makeOptionMandatory(true);
+
+const multiDeploymentBlockOption = new Option(
+  "--deployment-block <deploymentBlocks...>",
+  "Block number at which the ComposableCoW contract was deployed on the respective chains"
+).makeOptionMandatory(true);
+
+const deploymentBlockOption = new Option(
+  "--deployment-block <deploymentBlock>",
+  "Block number at which the ComposableCoW was deployed"
+)
+  .makeOptionMandatory(true)
+  .argParser(parseIntOption);
+
 async function main() {
-  program.name("watchtower").description(description).version(version);
+  program.name("watch-tower").description(description).version(version);
 
   program
     .command("run")
-    .description("Run the watchtower")
+    .description("Run the watch-tower, monitoring only a single chain")
+    .addOption(rpcOption)
+    .addOption(deploymentBlockOption)
+    .addOption(databasePathOption)
+    .addOption(logLevelOption)
+    .addOption(watchdogTimeoutOption)
+    .addOption(pageSizeOption)
+    .addOption(dryRunOnlyOption)
+    .addOption(oneShotOption)
+    .addOption(disableApiOption)
+    .addOption(apiPortOption)
+    .addOption(disableNotificationsOption)
+    .addOption(slackWebhookOption)
+    .action((options) => {
+      const { logLevel } = options;
+      const [pageSize, apiPort, watchdogTimeout, deploymentBlock] = [
+        options.pageSize,
+        options.apiPort,
+        options.watchdogTimeout,
+        options.deploymentBlock,
+      ].map((value) => Number(value));
+
+      initLogging({ logLevel });
+
+      // Run the watch-tower
+      run({ ...options, deploymentBlock, pageSize, apiPort, watchdogTimeout });
+    });
+
+  program
+    .command("run-multi")
+    .description("Run the watch-tower monitoring multiple blockchains")
     .addHelpText(
       "before",
       "RPC and deployment blocks must be the same length, and in the same order"
     )
-    .requiredOption("--rpc <rpc...>", "Chain RPC endpoints to monitor")
-    .requiredOption(
-      "--deployment-block <deploymentBlock...>",
-      "Block number at which the contracts were deployed"
-    )
-    .addOption(
-      new Option("--page-size <pageSize>", "Number of blocks to fetch per page")
-        .default("5000")
-        .argParser(parseIntOption)
-    )
-    .option("--dry-run", "Do not publish orders to the OrderBook API", false)
-    .addOption(
-      new Option("--silent", "Disable notifications (local logging only)")
-        .conflicts(["slackWebhook"])
-        .default(false)
-    )
-    .option("--disable-api", "Disable the REST API", false)
-    .addOption(
-      new Option("--api-port <apiPort>", "Port for the REST API")
-        .default("8080")
-        .argParser(parseIntOption)
-    )
-    .option("--slack-webhook <slackWebhook>", "Slack webhook URL")
-    .option("--one-shot", "Run the watchtower once and exit", false)
-    .addOption(
-      new Option(
-        "--watchdog-timeout <watchdogTimeout>",
-        "Watchdog timeout (in seconds)"
-      )
-        .default("30")
-        .argParser(parseIntOption)
-    )
+    .addOption(multiRpcOption)
+    .addOption(multiDeploymentBlockOption)
+    .addOption(databasePathOption)
     .addOption(logLevelOption)
-    .option(
-      "--database-path <databasePath>",
-      "Path to the database",
-      "./database"
-    )
+    .addOption(watchdogTimeoutOption)
+    .addOption(pageSizeOption)
+    .addOption(dryRunOnlyOption)
+    .addOption(oneShotOption)
+    .addOption(disableApiOption)
+    .addOption(apiPortOption)
+    .addOption(disableNotificationsOption)
+    .addOption(slackWebhookOption)
     .action((options) => {
       const { logLevel } = options;
       const [pageSize, apiPort, watchdogTimeout] = [
@@ -71,21 +150,30 @@ async function main() {
       ].map((value) => Number(value));
 
       initLogging({ logLevel });
-      const { rpc, deploymentBlock: deploymentBlockEnv } = options;
+      const { rpc: rpcs, deploymentBlock: deploymentBlocksEnv } = options;
 
       // Ensure that the deployment blocks are all numbers
-      const deploymentBlock = deploymentBlockEnv.map((block) => Number(block));
-      if (deploymentBlock.some((block) => isNaN(block))) {
+      const deploymentBlocks = deploymentBlocksEnv.map((block) =>
+        Number(block)
+      );
+      if (deploymentBlocks.some((block) => isNaN(block))) {
         throw new Error("Deployment blocks must be numbers");
       }
 
       // Ensure that the RPCs and deployment blocks are the same length
-      if (rpc.length !== deploymentBlock.length) {
+      if (rpcs.length !== deploymentBlocks.length) {
         throw new Error("RPC and deployment blocks must be the same length");
       }
 
-      // Run the watchtower
-      run({ ...options, deploymentBlock, pageSize, apiPort, watchdogTimeout });
+      // Run the watch-tower
+      runMulti({
+        ...options,
+        rpcs,
+        deploymentBlocks,
+        pageSize,
+        apiPort,
+        watchdogTimeout,
+      });
     });
 
   program
@@ -93,11 +181,7 @@ async function main() {
     .description("Dump database as JSON to STDOUT")
     .requiredOption("--chain-id <chainId>", "Chain ID to dump")
     .addOption(logLevelOption)
-    .option(
-      "--database-path <databasePath>",
-      "Path to the database",
-      "./database"
-    )
+    .addOption(databasePathOption)
     .action((options) => {
       const { logLevel } = options;
       initLogging({ logLevel });
@@ -117,13 +201,9 @@ async function main() {
     .description("Replay a block")
     .requiredOption("--rpc <rpc>", "Chain RPC endpoint to execute on")
     .requiredOption("--block <block>", "Block number to replay")
-    .option("--dry-run", "Do not publish orders to the OrderBook API", false)
+    .addOption(dryRunOnlyOption)
     .addOption(logLevelOption)
-    .option(
-      "--database-path <databasePath>",
-      "Path to the database",
-      "./database"
-    )
+    .addOption(databasePathOption)
     .action((options) => {
       const { logLevel } = options;
       initLogging({ logLevel });
@@ -140,15 +220,11 @@ async function main() {
   program
     .command("replay-tx")
     .description("Reply a transaction")
-    .requiredOption("--rpc <rpc>", "Chain RPC endpoint to execute on")
-    .requiredOption("--tx <tx>", "Transaction hash to replay")
-    .option("--dry-run", "Do not publish orders to the OrderBook API", false)
+    .addOption(rpcOption)
+    .addOption(dryRunOnlyOption)
     .addOption(logLevelOption)
-    .option(
-      "--database-path <databasePath>",
-      "Path to the database",
-      "./database"
-    )
+    .addOption(databasePathOption)
+    .requiredOption("--tx <tx>", "Transaction hash to replay")
     .action((options: ReplayTxOptions) => {
       const { logLevel } = options;
       initLogging({ logLevel });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,8 +12,6 @@ export interface WatchtowerReplayOptions extends WatchtowerOptions {
 }
 
 export interface RunOptions extends WatchtowerOptions {
-  rpc: string[];
-  deploymentBlock: number[];
   pageSize: number;
   silent: boolean;
   slackWebhook?: string;
@@ -23,10 +21,15 @@ export interface RunOptions extends WatchtowerOptions {
   watchdogTimeout: number;
 }
 
-export type SingularRunOptions = Omit<RunOptions, "rpc" | "deploymentBlock"> & {
+export interface RunSingleOptions extends RunOptions {
   rpc: string;
   deploymentBlock: number;
-};
+}
+
+export interface RunMultiOptions extends RunOptions {
+  rpcs: string[];
+  deploymentBlocks: number[];
+}
 
 export interface ReplayBlockOptions extends WatchtowerReplayOptions {
   block: number;

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,7 +1,7 @@
 import Slack = require("node-slack");
 import { DBService } from "./db";
 
-import { ExecutionContext, Registry, SingularRunOptions } from "../types";
+import { ExecutionContext, Registry, RunSingleOptions } from "../types";
 import { SupportedChainId } from "@cowprotocol/cow-sdk";
 import { getLogger } from "./logging";
 
@@ -12,7 +12,7 @@ let executionContext: ExecutionContext | undefined;
 export async function initContext(
   transactionName: string,
   chainId: SupportedChainId,
-  options: SingularRunOptions
+  options: RunSingleOptions
 ): Promise<ExecutionContext> {
   // Init storage
   const storage = DBService.getInstance();
@@ -37,7 +37,7 @@ export async function initContext(
   return executionContext;
 }
 
-function _getSlack(options: SingularRunOptions): Slack | undefined {
+function _getSlack(options: RunSingleOptions): Slack | undefined {
   if (executionContext) {
     return executionContext?.slack;
   }


### PR DESCRIPTION
# Description
A long requested feature has been to enable single-chain running of the watch-tower (as is currently done on CoW Protocol infrastructure).

# Changes

- [x] Extracted all common options from `commander` to variables to DRY commander config.
- [x] Changed `run` to not take variadic `rpc` and `deploymentBlock`. Singular input only.
- [x] Introduced `run-multi` command that has the same functionality that `run` had previously.
- [x] Set all options to be configurable via environment variable, except variadic options on `run-multi`.
 
## How to test

1. Attempt to start a single chain as per instructions in the readme.

## Related Issues

Fixes #71 