### PR TITLE
chore: address filter and chain config

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,22 @@ As an example, to run the latest version of the watch-tower via `docker`:
 docker run --rm -it \
   ghcr.io/cowprotocol/watch-tower:latest \
   run \
-  --chain-config <rpc>,<deployment-block>,<watchdog-timeout> \
+  --chain-config <rpc>,<deployment-block> \
   --page-size 5000
 ```
 
-**NOTE**: `watchdog-timeout` above is _optional_. If not specified, the default is 30 seconds. This is the timeout from which if the watch-tower does not receive a new block, it will exit, or signal non-live to Kubernetes. This is used to restart the watch-tower in the event of a RPC / network failure.
+**NOTE**: There are multiple optional arguments on the `--chain-config` parameter. For a full explanation of the optional arguments, use the `--help` flag:
 
-### Dappnode
+  ```bash
+  docker run --rm -it \
+    ghcr.io/cowprotocol/watch-tower:latest \
+    run \
+    --help
+  ```
 
-**TODO**: Add instructions for deploying to Dappnode.
+### DAppNode
+
+For [DAppNode](https://dappnode.com), the watch-tower is available as a package. This package is held in a [separate repository](https://github.com/cowprotocol/dappnodepackage-cow-watch-tower).
 
 ### Running locally
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ As an example, to run the latest version of the watch-tower via `docker`:
 docker run --rm -it \
   ghcr.io/cowprotocol/watch-tower:latest \
   run \
-  --chain-config <rpc-url>,<deployment-block>,<watchdog-timeout> \
+  --chain-config <rpc>,<deployment-block>,<watchdog-timeout> \
   --page-size 5000
 ```
 
@@ -56,7 +56,7 @@ docker run --rm -it \
 # Install dependencies
 yarn
 # Run watch-tower
-yarn cli run --chain-config <rpc-url>,<deployment-block> --page-size 5000
+yarn cli run --chain-config <rpc>,<deployment-block> --page-size 5000
 ```
 
 ## Architecture
@@ -179,7 +179,7 @@ It is recommended to test against the Goerli testnet. To run the watch-tower:
 # Install dependencies
 yarn
 # Run watch-tower
-yarn cli run --chain-config <rpc-url>,<deployment-block> --page-size 5000
+yarn cli run --chain-config <rpc>,<deployment-block> --page-size 5000
 ```
 
 ### Testing

--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ As an example, to run the latest version of the watch-tower via `docker`:
 docker run --rm -it \
   ghcr.io/cowprotocol/watch-tower:latest \
   run \
-  --rpc <rpc-url> \
-  --deployment-block <deployment-block> \
+  --chain-config <rpc-url>,<deployment-block>,<watchdog-timeout> \
   --page-size 5000
 ```
+
+**NOTE**: `watchdog-timeout` above is _optional_. If not specified, the default is 30 seconds. This is the timeout from which if the watch-tower does not receive a new block, it will exit, or signal non-live to Kubernetes. This is used to restart the watch-tower in the event of a RPC / network failure.
 
 ### Dappnode
 
@@ -55,7 +56,7 @@ docker run --rm -it \
 # Install dependencies
 yarn
 # Run watch-tower
-yarn cli run --rpc <rpc-url> --deployment-block <deployment-block> --page-size 5000
+yarn cli run --chain-config <rpc-url>,<deployment-block> --page-size 5000
 ```
 
 ## Architecture
@@ -178,7 +179,7 @@ It is recommended to test against the Goerli testnet. To run the watch-tower:
 # Install dependencies
 yarn
 # Run watch-tower
-yarn cli run --rpc <rpc-url> --deployment-block <deployment-block> --page-size 5000
+yarn cli run --chain-config <rpc-url>,<deployment-block> --page-size 5000
 ```
 
 ### Testing

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -9,8 +9,7 @@ import { ApiService } from "../utils/api";
  */
 export async function run(options: RunSingleOptions) {
   const log = getLogger("commands:run");
-  const { oneShot, disableApi, apiPort, databasePath, watchdogTimeout } =
-    options;
+  const { oneShot, disableApi, apiPort, databasePath } = options;
 
   // Open the database
   const storage = DBService.getInstance(databasePath);
@@ -35,7 +34,7 @@ export async function run(options: RunSingleOptions) {
   let exitCode = 0;
   try {
     const chainContext = await ChainContext.init(options, storage);
-    const runPromise = chainContext.warmUp(watchdogTimeout, oneShot);
+    const runPromise = chainContext.warmUp(oneShot);
 
     // Run the block watcher after warm up for the chain
     await runPromise;

--- a/src/commands/runMulti.ts
+++ b/src/commands/runMulti.ts
@@ -16,7 +16,7 @@ export async function runMulti(options: RunMultiOptions) {
     disableApi,
     apiPort,
     databasePath,
-    watchdogTimeout,
+    watchdogTimeouts,
   } = options;
 
   // Open the database
@@ -48,6 +48,7 @@ export async function runMulti(options: RunMultiOptions) {
             ...options,
             rpc,
             deploymentBlock: deploymentBlocks[index],
+            watchdogTimeout: watchdogTimeouts[index],
           },
           storage
         );
@@ -56,7 +57,7 @@ export async function runMulti(options: RunMultiOptions) {
 
     // Run the block watcher after warm up for each chain
     const runPromises = chainContexts.map(async (context) => {
-      return context.warmUp(watchdogTimeout, oneShot);
+      return context.warmUp(oneShot);
     });
 
     // Run all the chain contexts

--- a/src/commands/runMulti.ts
+++ b/src/commands/runMulti.ts
@@ -12,6 +12,7 @@ export async function runMulti(options: RunMultiOptions) {
   const {
     rpcs,
     deploymentBlocks,
+    orderBookApis,
     oneShot,
     disableApi,
     apiPort,
@@ -49,6 +50,7 @@ export async function runMulti(options: RunMultiOptions) {
             rpc,
             deploymentBlock: deploymentBlocks[index],
             watchdogTimeout: watchdogTimeouts[index],
+            orderBookApi: orderBookApis[index],
           },
           storage
         );

--- a/src/commands/runMulti.ts
+++ b/src/commands/runMulti.ts
@@ -12,12 +12,12 @@ export async function runMulti(options: RunMultiOptions) {
   const {
     rpcs,
     deploymentBlocks,
+    watchdogTimeouts,
     orderBookApis,
     oneShot,
     disableApi,
     apiPort,
     databasePath,
-    watchdogTimeouts,
   } = options;
 
   // Open the database

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -282,7 +282,9 @@ export class ChainContext {
         oneShot ? "Chain watcher is in sync" : "Chain watcher is warmed up"
       }`
     );
-    log.debug(`Last processed block: ${this.registry.lastProcessedBlock}`);
+    log.debug(
+      `Last processed block: ${this.registry.lastProcessedBlock.number}`
+    );
 
     // If one-shot, return
     if (oneShot) {
@@ -362,14 +364,13 @@ export class ChainContext {
       const now = Math.floor(new Date().getTime() / 1000);
       const timeElapsed = now - lastBlockReceived.timestamp;
 
-      log.debug(`Time since last block processed: ${timeElapsed}ms`);
+      log.debug(`Time since last block processed: ${timeElapsed}s`);
 
       // If we haven't received a block within `watchdogTimeout` seconds, either signal
       // an error or exit if not running in a kubernetes pod
-      if (timeElapsed >= watchdogTimeout * 1000) {
-        const formattedElapsedTime = Math.floor(timeElapsed / 1000);
+      if (timeElapsed >= watchdogTimeout) {
         log.error(
-          `Chain watcher last processed a block ${formattedElapsedTime}s ago (${watchdogTimeout}s timeout configured). Check the RPC.`
+          `Chain watcher last processed a block ${timeElapsed}s ago (${watchdogTimeout}s timeout configured). Check the RPC.`
         );
         if (isRunningInKubernetesPod()) {
           this.sync = ChainSync.UNKNOWN;

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -92,11 +92,16 @@ export class ChainContext {
     options: RunSingleOptions,
     provider: providers.Provider,
     chainId: SupportedChainId,
-    registry: Registry,
-    orderBookApi?: string
+    registry: Registry
   ) {
-    const { deploymentBlock, pageSize, dryRun, watchdogTimeout, addresses } =
-      options;
+    const {
+      deploymentBlock,
+      pageSize,
+      dryRun,
+      watchdogTimeout,
+      addresses,
+      orderBookApi,
+    } = options;
     this.deploymentBlock = deploymentBlock;
     this.pageSize = pageSize;
     this.dryRun = dryRun;
@@ -135,7 +140,7 @@ export class ChainContext {
     options: RunSingleOptions,
     storage: DBService
   ): Promise<ChainContext> {
-    const { rpc, orderBookApi, deploymentBlock } = options;
+    const { rpc, deploymentBlock } = options;
 
     const provider = new providers.JsonRpcProvider(rpc);
     const chainId = (await provider.getNetwork()).chainId;
@@ -147,13 +152,7 @@ export class ChainContext {
     );
 
     // Save the context to the static map to be used by the API
-    const context = new ChainContext(
-      options,
-      provider,
-      chainId,
-      registry,
-      orderBookApi
-    );
+    const context = new ChainContext(options, provider, chainId, registry);
     ChainContext.chains[chainId] = context;
 
     return context;
@@ -162,7 +161,6 @@ export class ChainContext {
   /**
    * Warm up the chain watcher by fetching the latest block number and
    * checking if the chain is in sync.
-   * @param watchdogTimeout the timeout for the watchdog
    * @param oneShot if true, only warm up the chain watcher and return
    * @returns the run promises for what needs to be watched
    */

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -86,7 +86,6 @@ export class ChainContext {
   orderBook: OrderBookApi;
   contract: ComposableCoW;
   multicall: Multicall3;
-  orderBookApiBaseUrls?: ApiBaseUrls;
 
   protected constructor(
     options: RunSingleOptions,
@@ -106,15 +105,16 @@ export class ChainContext {
     this.provider = provider;
     this.chainId = chainId;
     this.registry = registry;
-    this.orderBookApiBaseUrls = orderBookApi
+
+    const baseUrls = orderBookApi
       ? ({
           [this.chainId]: orderBookApi,
         } as ApiBaseUrls) // FIXME: do not do this casting once this is fixed https://github.com/cowprotocol/cow-sdk/issues/176
       : undefined;
 
     this.orderBook = new OrderBookApi({
-      chainId: this.chainId,
-      baseUrls: this.orderBookApiBaseUrls,
+      chainId,
+      baseUrls,
       backoffOpts: {
         numOfAttempts: SDK_BACKOFF_NUM_OF_ATTEMPTS,
       },

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -191,6 +191,14 @@ export class ChainContext {
           toBlock =
             toBlock > currentBlock.number ? currentBlock.number : toBlock;
 
+          // This happens when the watch-tower has restarted and the last processed block is
+          // the current block. Therefore the `fromBlock` is the current block + 1, which is
+          // greater than the current block number. In this case, we are in sync.
+          if (fromBlock > currentBlock.number) {
+            this.sync = ChainSync.IN_SYNC;
+            break;
+          }
+
           log.debug(
             `Reaching tip of chain, current block number: ${currentBlock.number}`
           );

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -77,6 +77,7 @@ export class ChainContext {
   readonly dryRun: boolean;
   readonly watchdogTimeout: number;
   readonly addresses?: string[];
+  readonly orderBookApiBaseUrls?: ApiBaseUrls;
   private sync: ChainSync = ChainSync.SYNCING;
   static chains: Chains = {};
 
@@ -106,7 +107,7 @@ export class ChainContext {
     this.chainId = chainId;
     this.registry = registry;
 
-    const baseUrls = orderBookApi
+    this.orderBookApiBaseUrls = orderBookApi
       ? ({
           [this.chainId]: orderBookApi,
         } as ApiBaseUrls) // FIXME: do not do this casting once this is fixed https://github.com/cowprotocol/cow-sdk/issues/176
@@ -114,7 +115,7 @@ export class ChainContext {
 
     this.orderBook = new OrderBookApi({
       chainId,
-      baseUrls,
+      baseUrls: this.orderBookApiBaseUrls,
       backoffOpts: {
         numOfAttempts: SDK_BACKOFF_NUM_OF_ATTEMPTS,
       },

--- a/src/domain/chainContext.ts
+++ b/src/domain/chainContext.ts
@@ -99,14 +99,14 @@ export class ChainContext {
       pageSize,
       dryRun,
       watchdogTimeout,
-      addresses,
+      owners,
       orderBookApi,
     } = options;
     this.deploymentBlock = deploymentBlock;
     this.pageSize = pageSize;
     this.dryRun = dryRun;
     this.watchdogTimeout = watchdogTimeout;
-    this.addresses = addresses;
+    this.addresses = owners;
 
     this.provider = provider;
     this.chainId = chainId;

--- a/src/domain/checkForAndPlaceOrder.ts
+++ b/src/domain/checkForAndPlaceOrder.ts
@@ -263,6 +263,8 @@ async function _processConditionalOrder(
         blockNumber,
       },
       provider,
+      // TODO: This should be DRY'ed. Upstream should take just an `orderBook` object that
+      //       is already configured.
       orderbookApiConfig: {
         baseUrls: orderBookApiBaseUrls,
         backoffOpts: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ const databasePathOption = new Option(
   .default(DEFAULT_DATABASE_PATH)
   .env("DATABASE_PATH");
 
-const chainConfigHelp = `Chain configuration in the format of <rpc>,<deploymentBlock>[,<orderBookApi>,<watchdogTimeout>], e.g. http://erigon.dappnode:8545,12345678,https://api.cow.fi/mainnet,30`;
+const chainConfigHelp = `Chain configuration in the format of <rpc>,<deploymentBlock>[,<watchdogTimeout>,<orderBookApi>], e.g. http://erigon.dappnode:8545,12345678,30,https://api.cow.fi/mainnet`;
 const multiChainConfigOption = new Option(
   "--chain-config <chainConfig...>",
   chainConfigHelp
@@ -231,7 +231,7 @@ function parseChainConfigOption(option: string): ChainConfigOptions {
   // Ensure there are at least two parts (rpc and deploymentBlock)
   if (parts.length < 2) {
     throw new InvalidArgumentError(
-      `Chain configuration must be in the format of <rpc>,<deploymentBlock>[,<orderBookApi>,<watchdogTimeout>], e.g. http://erigon.dappnode:8545,12345678,https://api.cow.fi/mainnet,30`
+      `Chain configuration must be in the format of <rpc>,<deploymentBlock>[,<watchdogTimeout>,<orderBookApi>], e.g. http://erigon.dappnode:8545,12345678,30,https://api.cow.fi/mainnet`
     );
   }
 
@@ -253,22 +253,22 @@ function parseChainConfigOption(option: string): ChainConfigOptions {
     );
   }
 
-  // If there is a third part, it is the orderBookApi
-  const orderBookApi = parts.length > 2 ? parts[2] : undefined;
-  // Ensure that the orderBookApi is a valid URL
-  if (orderBookApi && !isValidUrl(orderBookApi)) {
-    throw new InvalidArgumentError(
-      `${orderBookApi} must be a valid URL (orderBookApi)`
-    );
-  }
-
-  const rawWatchdogTimeout = parts[3];
-  // If there is a fourth part, it is the watchdogTimeout
-  const watchdogTimeout = parts.length > 3 ? Number(rawWatchdogTimeout) : 30;
+  const rawWatchdogTimeout = parts[2];
+  // If there is a third part, it is the watchdogTimeout
+  const watchdogTimeout = parts.length > 2 ? Number(rawWatchdogTimeout) : 30;
   // Ensure that the watchdogTimeout is a number
   if (isNaN(watchdogTimeout)) {
     throw new InvalidArgumentError(
       `${rawWatchdogTimeout} must be a number (watchdogTimeout)`
+    );
+  }
+
+  // If there is a fourth part, it is the orderBookApi
+  const orderBookApi = parts.length > 3 ? parts[3] : undefined;
+  // Ensure that the orderBookApi is a valid URL
+  if (orderBookApi && !isValidUrl(orderBookApi)) {
+    throw new InvalidArgumentError(
+      `${orderBookApi} must be a valid URL (orderBookApi)`
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,7 @@ const databasePathOption = new Option(
   .default(DEFAULT_DATABASE_PATH)
   .env("DATABASE_PATH");
 
-const chainConfigHelp = `Chain configuration in the format of <rpc>,<deploymentBlock>,<watchdogTimeout>, e.g. http://erigon.dappnode:8545,12345678,30`;
+const chainConfigHelp = `Chain configuration in the format of <rpc>,<deploymentBlock>[,<orderBookApi>,<watchdogTimeout>], e.g. http://erigon.dappnode:8545,12345678,https://api.cow.fi/mainnet,30`;
 const multiChainConfigOption = new Option(
   "--chain-config <chainConfig...>",
   chainConfigHelp

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@ import {
   Option,
   InvalidArgumentError,
 } from "@commander-js/extra-typings";
-import { ReplayTxOptions } from "./types";
+import { MultiChainConfigOptions, ChainConfigOptions } from "./types";
+import { getAddress, isHexString } from "ethers/lib/utils";
 import { dumpDb, replayBlock, replayTx, run, runMulti } from "./commands";
 import { initLogging } from "./utils";
 import { version, description } from "../package.json";
@@ -63,14 +64,6 @@ const slackWebhookOption = new Option(
   "Slack webhook URL"
 ).env("SLACK_WEBHOOK");
 
-const watchdogTimeoutOption = new Option(
-  "--watchdog-timeout <watchdogTimeout>",
-  "Watchdog timeout (in seconds)"
-)
-  .default("30")
-  .env("WATCHDOG_TIMEOUT")
-  .argParser(parseIntOption);
-
 const databasePathOption = new Option(
   "--database-path <databasePath>",
   "Path to the database"
@@ -78,37 +71,26 @@ const databasePathOption = new Option(
   .default(DEFAULT_DATABASE_PATH)
   .env("DATABASE_PATH");
 
-const multiRpcOption = new Option(
-  "--rpc <rpc...>",
-  "Chain RPC endpoints to monitor"
-).makeOptionMandatory(true);
-
-const rpcOption = new Option("--rpc <rpc>", "Chain RPC endpoint to monitor")
-  .makeOptionMandatory(true)
-  .env("RPC");
-
-const multiDeploymentBlockOption = new Option(
-  "--deployment-block <deploymentBlocks...>",
-  "Block number at which the ComposableCoW contract was deployed on the respective chains"
-).makeOptionMandatory(true);
-
-const deploymentBlockOption = new Option(
-  "--deployment-block <deploymentBlock>",
-  "Block number at which the ComposableCoW was deployed"
+const chainConfigHelp = `Chain configuration in the format of <rpc>,<deploymentBlock>,<watchdogTimeout>, e.g. http://erigon.dappnode:8545,12345678,30`;
+const multiChainConfigOption = new Option(
+  "--chain-config <chainConfig...>",
+  chainConfigHelp
 )
   .makeOptionMandatory(true)
-  .env("DEPLOYMENT_BLOCK")
-  .argParser(parseIntOption);
+  .argParser(parseChainConfigOptions);
 
-const multiOrderBookApiOption = new Option(
-  "--orderBookApi <orderBookApi...>",
-  "Orderbook API base URLs (i.e. https://api.cow.fi/mainnet, https://api.cow.fi/xdai, etc.)"
-).default([]);
+const chainConfigOption = new Option(
+  "--chain-config <chainConfig>",
+  chainConfigHelp
+)
+  .makeOptionMandatory(true)
+  .env("CHAIN_CONFIG")
+  .argParser(parseChainConfigOption);
 
-const orderBookApiOption = new Option(
-  "--orderBookApi <orderBookApi>",
-  "Orderbook API base URL (i.e. https://api.cow.fi/mainnet)"
-).default(undefined);
+const addressOption = new Option(
+  "--address <address...>",
+  "Addresses of Safes to monitor conditional orders for"
+).argParser(parseAddressOption);
 
 async function main() {
   program.name("watch-tower").description(description).version(version);
@@ -116,12 +98,10 @@ async function main() {
   program
     .command("run")
     .description("Run the watch-tower, monitoring only a single chain")
-    .addOption(rpcOption)
-    .addOption(deploymentBlockOption)
-    .addOption(orderBookApiOption)
+    .addOption(chainConfigOption)
+    .addOption(addressOption)
     .addOption(databasePathOption)
     .addOption(logLevelOption)
-    .addOption(watchdogTimeoutOption)
     .addOption(pageSizeOption)
     .addOption(dryRunOnlyOption)
     .addOption(oneShotOption)
@@ -130,41 +110,24 @@ async function main() {
     .addOption(disableNotificationsOption)
     .addOption(slackWebhookOption)
     .action((options) => {
-      const { logLevel, orderBookApi } = options;
-
-      const [pageSize, apiPort, watchdogTimeout, deploymentBlock] = [
-        options.pageSize,
-        options.apiPort,
-        options.watchdogTimeout,
-        options.deploymentBlock,
-      ].map((value) => Number(value));
+      const { logLevel, chainConfig, address: addresses } = options;
+      const [pageSize, apiPort] = [options.pageSize, options.apiPort].map(
+        (value) => Number(value)
+      );
 
       initLogging({ logLevel });
 
       // Run the watch-tower
-      run({
-        ...options,
-        deploymentBlock,
-        orderBookApi,
-        pageSize,
-        apiPort,
-        watchdogTimeout,
-      });
+      run({ ...options, ...chainConfig, addresses, pageSize, apiPort });
     });
 
   program
     .command("run-multi")
     .description("Run the watch-tower monitoring multiple blockchains")
-    .addHelpText(
-      "before",
-      "RPC and deployment blocks must be the same length, and in the same order"
-    )
-    .addOption(multiRpcOption)
-    .addOption(multiDeploymentBlockOption)
-    .addOption(multiOrderBookApiOption)
+    .addOption(multiChainConfigOption)
+    .addOption(addressOption)
     .addOption(databasePathOption)
     .addOption(logLevelOption)
-    .addOption(watchdogTimeoutOption)
     .addOption(pageSizeOption)
     .addOption(dryRunOnlyOption)
     .addOption(oneShotOption)
@@ -173,47 +136,24 @@ async function main() {
     .addOption(disableNotificationsOption)
     .addOption(slackWebhookOption)
     .action((options) => {
-      const { logLevel } = options;
-      const [pageSize, apiPort, watchdogTimeout] = [
-        options.pageSize,
-        options.apiPort,
-        options.watchdogTimeout,
-      ].map((value) => Number(value));
+      const {
+        logLevel,
+        chainConfig: chainConfigs,
+        address: addresses,
+      } = options;
+      const [pageSize, apiPort] = [options.pageSize, options.apiPort].map(
+        (value) => Number(value)
+      );
 
       initLogging({ logLevel });
-      const {
-        rpc: rpcs,
-        orderBookApi: orderBookApis,
-        deploymentBlock: deploymentBlocksEnv,
-      } = options;
-
-      // Ensure that the deployment blocks are all numbers
-      const deploymentBlocks = deploymentBlocksEnv.map((block) =>
-        Number(block)
-      );
-      if (deploymentBlocks.some((block) => isNaN(block))) {
-        throw new Error("Deployment blocks must be numbers");
-      }
-
-      // Ensure that the RPCs and deployment blocks are the same length
-      if (rpcs.length !== deploymentBlocks.length) {
-        throw new Error("RPC and deployment blocks must be the same length");
-      }
-
-      // Ensure that the orderBookApis and RPCs are the same length
-      if (orderBookApis.length > 0 && rpcs.length !== orderBookApis.length) {
-        throw new Error("orderBookApi and RPC urls must be the same length");
-      }
 
       // Run the watch-tower
       runMulti({
         ...options,
-        rpcs,
-        deploymentBlocks,
-        orderBookApis,
+        ...chainConfigs,
+        addresses,
         pageSize,
         apiPort,
-        watchdogTimeout,
       });
     });
 
@@ -261,16 +201,16 @@ async function main() {
   program
     .command("replay-tx")
     .description("Reply a transaction")
-    .addOption(rpcOption)
+    .addOption(chainConfigOption)
     .addOption(dryRunOnlyOption)
     .addOption(logLevelOption)
     .addOption(databasePathOption)
     .requiredOption("--tx <tx>", "Transaction hash to replay")
-    .action((options: ReplayTxOptions) => {
-      const { logLevel } = options;
+    .action((options) => {
+      const { logLevel, chainConfig } = options;
       initLogging({ logLevel });
 
-      replayTx(options);
+      replayTx({ ...options, ...chainConfig });
     });
 
   await program.parseAsync();
@@ -282,6 +222,75 @@ function parseIntOption(option: string) {
     throw new InvalidArgumentError(`${option} must be a number`);
   }
   return parsed.toString();
+}
+
+function parseChainConfigOption(option: string): ChainConfigOptions {
+  // Split the option using ',' as the delimiter
+  const parts = option.split(",");
+
+  // Ensure there are at least two parts (rpc and deploymentBlock)
+  if (parts.length < 2) {
+    throw new InvalidArgumentError(
+      `Chain configuration must be in the format of <rpc>,<deploymentBlock>[,<watchdogTimeout>], e.g. http://erigon.dappnode:8545,12345678,30`
+    );
+  }
+
+  // Extract rpc and deploymentBlock from the parts
+  const rpc = parts[0];
+  const rawDeploymentBlock = parts[1];
+
+  // Ensure that the deployment block is a number
+  const deploymentBlock = Number(rawDeploymentBlock);
+  if (isNaN(deploymentBlock)) {
+    throw new InvalidArgumentError(
+      `${rawDeploymentBlock} must be a number (deployment block)`
+    );
+  }
+
+  // Default the watchdogTimeout to 30 seconds if not provided
+  const watchdogTimeout = parts.length > 2 ? Number(parts[2]) : 30;
+
+  // Ensure that the RPC is a valid URL
+  try {
+    new URL(rpc);
+  } catch (error) {
+    throw new InvalidArgumentError(`${rpc} must be a valid URL (RPC)`);
+  }
+
+  return { rpc, deploymentBlock, watchdogTimeout };
+}
+
+function parseChainConfigOptions(
+  option: string,
+  previous: MultiChainConfigOptions = {
+    rpcs: [],
+    deploymentBlocks: [],
+    watchdogTimeouts: [],
+    orderBookApis: [],
+  }
+): MultiChainConfigOptions {
+  const parsedOption = parseChainConfigOption(option);
+  const { rpc, deploymentBlock, watchdogTimeout } = parsedOption;
+
+  previous.rpcs.push(rpc);
+  previous.deploymentBlocks.push(deploymentBlock);
+  previous.watchdogTimeouts.push(watchdogTimeout);
+  return previous;
+}
+
+function parseAddressOption(option: string, previous: string[] = []): string[] {
+  // Use ethers to validate the address
+  try {
+    if (!isHexString(option)) {
+      throw new Error();
+    }
+    getAddress(option);
+  } catch (error) {
+    throw new InvalidArgumentError(
+      `${option} must be a valid '0x' prefixed address`
+    );
+  }
+  return [...previous, option];
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,9 +87,9 @@ const chainConfigOption = new Option(
   .env("CHAIN_CONFIG")
   .argParser(parseChainConfigOption);
 
-const addressOption = new Option(
-  "--address <address...>",
-  "Addresses of Safes to monitor conditional orders for"
+const onlyOwnerOption = new Option(
+  "--only-owner <onlyOwner...>",
+  "Addresses of contracts / safes to monitor conditional orders for"
 ).argParser(parseAddressOption);
 
 async function main() {
@@ -99,7 +99,7 @@ async function main() {
     .command("run")
     .description("Run the watch-tower, monitoring only a single chain")
     .addOption(chainConfigOption)
-    .addOption(addressOption)
+    .addOption(onlyOwnerOption)
     .addOption(databasePathOption)
     .addOption(logLevelOption)
     .addOption(pageSizeOption)
@@ -110,7 +110,7 @@ async function main() {
     .addOption(disableNotificationsOption)
     .addOption(slackWebhookOption)
     .action((options) => {
-      const { logLevel, chainConfig, address: addresses } = options;
+      const { logLevel, chainConfig, onlyOwner: owners } = options;
       const [pageSize, apiPort] = [options.pageSize, options.apiPort].map(
         (value) => Number(value)
       );
@@ -118,14 +118,14 @@ async function main() {
       initLogging({ logLevel });
 
       // Run the watch-tower
-      run({ ...options, ...chainConfig, addresses, pageSize, apiPort });
+      run({ ...options, ...chainConfig, owners, pageSize, apiPort });
     });
 
   program
     .command("run-multi")
     .description("Run the watch-tower monitoring multiple blockchains")
     .addOption(multiChainConfigOption)
-    .addOption(addressOption)
+    .addOption(onlyOwnerOption)
     .addOption(databasePathOption)
     .addOption(logLevelOption)
     .addOption(pageSizeOption)
@@ -139,7 +139,7 @@ async function main() {
       const {
         logLevel,
         chainConfig: chainConfigs,
-        address: addresses,
+        onlyOwner: owners,
       } = options;
       const [pageSize, apiPort] = [options.pageSize, options.apiPort].map(
         (value) => Number(value)
@@ -151,7 +151,7 @@ async function main() {
       runMulti({
         ...options,
         ...chainConfigs,
-        addresses,
+        owners,
         pageSize,
         apiPort,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,21 +245,21 @@ function parseChainConfigOption(option: string): ChainConfigOptions {
   }
 
   const rawDeploymentBlock = parts[1];
-  // Ensure that the deployment block is a number
+  // Ensure that the deployment block is a positive number
   const deploymentBlock = Number(rawDeploymentBlock);
-  if (isNaN(deploymentBlock)) {
+  if (isNaN(deploymentBlock) || deploymentBlock < 0) {
     throw new InvalidArgumentError(
-      `${rawDeploymentBlock} must be a number (deployment block)`
+      `${rawDeploymentBlock} must be a positive number (deployment block)`
     );
   }
 
   const rawWatchdogTimeout = parts[2];
   // If there is a third part, it is the watchdogTimeout
   const watchdogTimeout = parts.length > 2 ? Number(rawWatchdogTimeout) : 30;
-  // Ensure that the watchdogTimeout is a number
-  if (isNaN(watchdogTimeout)) {
+  // Ensure that the watchdogTimeout is a positive number
+  if (isNaN(watchdogTimeout) || watchdogTimeout < 0) {
     throw new InvalidArgumentError(
-      `${rawWatchdogTimeout} must be a number (watchdogTimeout)`
+      `${rawWatchdogTimeout} must be a positive number (watchdogTimeout)`
     );
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,15 +26,15 @@ export type OrderBookApi = string | undefined;
 export type ChainConfigOptions = {
   rpc: string;
   deploymentBlock: number;
-  orderBookApi: OrderBookApi;
   watchdogTimeout: number;
+  orderBookApi: OrderBookApi;
 };
 
 export type MultiChainConfigOptions = {
   rpcs: string[];
   deploymentBlocks: number[];
-  orderBookApis: OrderBookApi[];
   watchdogTimeouts: number[];
+  orderBookApis: OrderBookApi[];
 };
 
 export type RunSingleOptions = RunOptions & ChainConfigOptions;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,7 +18,7 @@ export type RunOptions = WatchtowerOptions & {
   oneShot: boolean;
   disableApi: boolean;
   apiPort: number;
-  addresses?: string[];
+  owners?: string[];
 };
 
 export type OrderBookApi = string | undefined;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,18 +21,20 @@ export type RunOptions = WatchtowerOptions & {
   addresses?: string[];
 };
 
+export type OrderBookApi = string | undefined;
+
 export type ChainConfigOptions = {
   rpc: string;
   deploymentBlock: number;
+  orderBookApi: OrderBookApi;
   watchdogTimeout: number;
-  orderBookApi?: string;
 };
 
 export type MultiChainConfigOptions = {
   rpcs: string[];
   deploymentBlocks: number[];
+  orderBookApis: OrderBookApi[];
   watchdogTimeouts: number[];
-  orderBookApis: string[];
 };
 
 export type RunSingleOptions = RunOptions & ChainConfigOptions;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,49 +1,54 @@
-export interface LogOptions {
+export type LogOptions = {
   logLevel: string;
   databasePath: string;
-}
+};
 
-export interface WatchtowerOptions extends LogOptions {
+export type WatchtowerOptions = LogOptions & {
   dryRun: boolean;
-}
+};
 
-export interface WatchtowerReplayOptions extends WatchtowerOptions {
+export type WatchtowerReplayOptions = WatchtowerOptions & {
   rpc: string;
-}
+};
 
-export interface RunOptions extends WatchtowerOptions {
+export type RunOptions = WatchtowerOptions & {
   pageSize: number;
   silent: boolean;
   slackWebhook?: string;
   oneShot: boolean;
   disableApi: boolean;
   apiPort: number;
-  watchdogTimeout: number;
-}
+  addresses?: string[];
+};
 
-export interface RunSingleOptions extends RunOptions {
+export type ChainConfigOptions = {
   rpc: string;
-  orderBookApi?: string;
   deploymentBlock: number;
-}
+  watchdogTimeout: number;
+  orderBookApi?: string;
+};
 
-export interface RunMultiOptions extends RunOptions {
+export type MultiChainConfigOptions = {
   rpcs: string[];
   deploymentBlocks: number[];
+  watchdogTimeouts: number[];
   orderBookApis: string[];
-}
+};
 
-export interface ReplayBlockOptions extends WatchtowerReplayOptions {
+export type RunSingleOptions = RunOptions & ChainConfigOptions;
+export type RunMultiOptions = RunOptions & MultiChainConfigOptions;
+
+export type ReplayBlockOptions = WatchtowerReplayOptions & {
   block: number;
-}
+};
 
-export interface ReplayTxOptions extends WatchtowerReplayOptions {
+export type ReplayTxOptions = WatchtowerReplayOptions & {
   tx: string;
-}
+};
 
-export interface DumpDbOptions extends LogOptions {
+export type DumpDbOptions = LogOptions & {
   chainId: number;
-}
+};
 
 export type ToBlock = "latest" | number;
 


### PR DESCRIPTION
# Description
This PR tweaks some configuration options for easing deployment on dappnode.

# Changes

- [x] `rpc`, `deploymentBlock`, `watchdogTimeout`, and `orderBookApi` collapsed down into `chain-config` 
- [x] Added `ChainConfig` option parser
- [x] Added user-defined `address` filter (only process conditional orders from specific addresses)
- [x] Fixes a calculation issue with the watchdog
 
## How to test

1. Follow the readme instructions for quickly running
2. Observe no errors

## Related Issues

Fixes: #72 