### PR TITLE
feat: add default action for filtering

### DIFF
--- a/src/utils/filterPolicy.ts
+++ b/src/utils/filterPolicy.ts
@@ -7,6 +7,7 @@ export enum FilterAction {
 }
 
 interface PolicyConfig {
+  defaultAction: FilterAction;
   owners: Map<string, FilterAction>;
   handlers: Map<string, FilterAction>;
 }
@@ -48,7 +49,7 @@ export class FilterPolicy {
       return action;
     }
 
-    return FilterAction.ACCEPT;
+    return this.config.defaultAction;
   }
 
   /**
@@ -77,6 +78,7 @@ export class FilterPolicy {
     }
     const config = await configResponse.json();
     return {
+      defaultAction: config.defaultAction,
       owners: new Map(Object.entries(config.owners)),
       handlers: new Map(Object.entries(config.handlers)),
     };


### PR DESCRIPTION
# Description
Closes #117 

Allows to create both DENY-LISTS, and WHITE-LISTS

For that, this PR introduces the default action, which could be: `ACCEPT`, `SKIP` or `DROP`

## Config
Now the config files are splitted by environment: `prod` and `staging`

See:
https://github.com/cowprotocol/watch-tower/tree/config

Production files have `DROP` as their default. They will whitelist all handlers in https://github.com/cowprotocol/composable-cow#deployed-contracts

Staging will default to index all orders. It will have some exceptions for orders.

# Test


```bash
LOG_LEVEL=DEBUG,checkForAndPlaceOrder=DEBUG \
  yarn ts-node ./src/index.ts run \
  --chain-config <RPC>,,,https://raw.githubusercontent.com/cowprotocol/watch-tower/config/prod/filter-policy-100.json \
  --page-size 5000 
```


Actually, i can see if I run it with PROd config, is pleasantly not noisy at all! A bit chat on boot to detect the TWAPs that should be created. The watch tower realises they were already created and we just need to schedule next poll. Then it becomes silent!

<img width="1727" alt="image" src="https://github.com/cowprotocol/watch-tower/assets/2352112/929fcb26-d02d-466d-bb25-ce6d4ae0c298">
