### PR TITLE
feat: add basic auth

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,7 +71,9 @@ const databasePathOption = new Option(
   .default(DEFAULT_DATABASE_PATH)
   .env("DATABASE_PATH");
 
-const chainConfigHelp = `Chain configuration in the format of <rpc>,<deploymentBlock>[,<watchdogTimeout>,<orderBookApi>,<filterPolicyConfig>], e.g. http://erigon.dappnode:8545,12345678,30,https://api.cow.fi/mainnet,https://raw.githubusercontent.com/cowprotocol/watch-tower/config/filter-policy-1.json`;
+const CHAIN_CONFIG_PARAMS =
+  "<rpc>,<deploymentBlock>[,<watchdogTimeout>,<orderBookApi>,<filterPolicyConfig>,<rpcUser>,<rpcPassword>";
+const chainConfigHelp = `Chain configuration in the format of ${CHAIN_CONFIG_PARAMS}], e.g. http://erigon.dappnode:8545,12345678,30,https://api.cow.fi/mainnet,https://raw.githubusercontent.com/cowprotocol/watch-tower/config/filter-policy-1.json`;
 const multiChainConfigOption = new Option(
   "--chain-config <chainConfig...>",
   chainConfigHelp
@@ -231,7 +233,7 @@ function parseChainConfigOption(option: string): ChainConfigOptions {
   // Ensure there are at least two parts (rpc and deploymentBlock)
   if (parts.length < 2) {
     throw new InvalidArgumentError(
-      `Chain configuration must be in the format of <rpc>,<deploymentBlock>[,<watchdogTimeout>,<orderBookApi>,<filterPolicyConfig>], e.g. http://erigon.dappnode:8545,12345678,30,https://api.cow.fi/mainnet,https://raw.githubusercontent.com/cowprotocol/watch-tower/config/filter-policy-1.json`
+      `Chain configuration must be in the format of ${CHAIN_CONFIG_PARAMS}], e.g. http://erigon.dappnode:8545,12345678,30,https://api.cow.fi/mainnet,https://raw.githubusercontent.com/cowprotocol/watch-tower/config/filter-policy-1.json`
     );
   }
 
@@ -283,8 +285,16 @@ function parseChainConfigOption(option: string): ChainConfigOptions {
     );
   }
 
+  // If there is a sixth part, it is the rpcUser
+  const rpcUserConfig = parts.length > 5 && parts[5] ? parts[5] : undefined;
+
+  // If there is a seventh part, it is the rpcUser
+  const rpcPasswordConfig = parts.length > 6 && parts[6] ? parts[6] : undefined;
+
   return {
     rpc,
+    rpcUser: rpcUserConfig,
+    rpcPassword: rpcPasswordConfig,
     deploymentBlock,
     watchdogTimeout,
     orderBookApi,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,8 @@ export type ChainConfigOptions = {
   watchdogTimeout: number;
   orderBookApi?: string;
   filterPolicyConfig?: string;
+  rpcUser?: string;
+  rpcPassword?: string;
   // filterPolicyConfigAuthToken?: string; // TODO: Implement authToken
 };
 


### PR DESCRIPTION
# Description
Implement basic auth for RPCs

This PR will make worse the problem we discussed about the chain config being too error prone. So Im glad of this, so we make it more obvious this needs to change (into individual params or a config file) --> out the scope

The PR adds also support for HTTP (but this should not be used in the wild internet!! just used to test and for some internal RPC that don't have HTTPS. Note that basic auth and HTTPS is a no-no!

# CTX
The motivation of this PR is that GC RPC endpoint started to fail. See https://cowservices.slack.com/archives/C0361CDD1FZ/p1700845414302179


# Test 
Just add user/password at the end. Credentials shared in 1password

Example:
```bash
yarn ts-node ./src/index.ts run --chain-config <rpc>,,,,https://raw.githubusercontent.com/cowprotocol/watch-tower/config/staging/filter-policy-100.json,<user>,<password> \ 
  --page-size 5000
```