### PR TITLE
chore: docker build node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS build
+FROM node:18-alpine AS build
 
 WORKDIR /usr/src/app
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ import { getAddress, isHexString } from "ethers/lib/utils";
 import { dumpDb, replayBlock, replayTx, run, runMulti } from "./commands";
 import { initLogging } from "./utils";
 import { version, description } from "../package.json";
+import { ethers, utils } from "ethers";
+
+// Enable trace logging
+ethers.utils.Logger.setLogLevel(utils.Logger.levels.DEBUG);
 
 const DEFAULT_DATABASE_PATH = "./database";
 


### PR DESCRIPTION
# Description

Testing with docker node version tracing a block decoding issue.

# Changes

- [x] Use Node v18
- [ ] ...

## How to test
1. Run in staging and observe JSON decoding results
