### PR TITLE
fix: missing config schema json in dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "main": "dist/src/index.js",
   "scripts": {
-    "build": "rm -rf dist && rm -rf src/types/generated && yarn typechain && tsc",
+    "build": "rm -rf dist && rm -rf src/types/generated && yarn typechain && tsc && cp ./src/types/config.schema.json dist/src/types/config.schema.json",
     "fmt": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint \"src/**/*.ts\" && prettier --check \"src/**/*.ts\"",
     "lint:fix": "eslint --fix \"src/**/*.ts\" && prettier --write \"src/**/*.ts\"",


### PR DESCRIPTION
# Description

This PR fixes missing config schemas in the build.

# Changes

- [x] Package the config schema JSON

## How to test

Edit the `config.example.json` as necessary.

1. `yarn build`
2. `node ./dist/src/index.js run --config-path ./config.example.json`
3. Observe the watch-tower starts without faults.