### PR TITLE
refactor: modular architecture

### DIFF
--- a/src/commands/dumpDb.ts
+++ b/src/commands/dumpDb.ts
@@ -1,5 +1,6 @@
 import { DumpDbOptions, Registry } from "../types";
-import { DBService, getLogger } from "../utils";
+import { DBService } from "../services";
+import { getLogger } from "../utils";
 
 /**
  * Dump the database as JSON to STDOUT for a given chain ID

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,6 @@
 import { RunOptions } from "../types";
-import { getLogger, DBService, ApiService } from "../utils";
-import { ChainContext } from "../domain";
+import { getLogger } from "../utils";
+import { DBService, ApiService, ChainContext } from "../services";
 
 /**
  * Run the watch-tower 👀🐮

--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -4,7 +4,7 @@ import {
   handleExecutionError,
   isComposableCowCompatible,
   metrics,
-} from "../utils";
+} from "../../utils";
 import { BytesLike, ethers } from "ethers";
 
 import {
@@ -17,9 +17,9 @@ import {
   Owner,
   Proof,
   Registry,
-} from "../types";
+} from "../../types";
 
-import { ChainContext } from "./chainContext";
+import { ChainContext } from "../../services/chain";
 import { ConditionalOrderParams } from "@cowprotocol/cow-sdk";
 
 /**

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,1 +1,2 @@
-export * from "./chainContext";
+export * as events from "./events";
+export * as polling from "./polling";

--- a/src/domain/polling/filtering/badOrder.ts
+++ b/src/domain/polling/filtering/badOrder.ts
@@ -1,12 +1,14 @@
 import { Order } from "@cowprotocol/contracts";
 import { BigNumber, ethers } from "ethers";
 
+const MINIMUM_VALIDITY_SECONDS = 60;
+
 /**
  * Process an order to determine if it is valid
  * @param order The GPv2.Order data struct to validate
  * @throws Error if the order is invalid
  */
-export function validateOrder(order: Order) {
+export function check(order: Order) {
   // amounts must be non-zero
   if (BigNumber.from(order.sellAmount).isZero()) {
     throw new Error("Order has zero sell amount");
@@ -30,8 +32,11 @@ export function validateOrder(order: Order) {
     throw new Error("Order has identical sell and buy token addresses");
   }
 
-  // Check to make sure that the order has at least 120s of validity
-  if (Math.floor(Date.now() / 1000) + 60 > Number(order.validTo)) {
+  // Check to make sure that the order has at least a specified validity
+  if (
+    Math.floor(Date.now() / 1000) + MINIMUM_VALIDITY_SECONDS >
+    Number(order.validTo)
+  ) {
     throw new Error("Order expires too soon");
   }
 }

--- a/src/domain/polling/filtering/index.ts
+++ b/src/domain/polling/filtering/index.ts
@@ -1,0 +1,2 @@
+export * as badOrder from "./badOrder";
+export * as policy from "./policy";

--- a/src/domain/polling/filtering/policy.ts
+++ b/src/domain/polling/filtering/policy.ts
@@ -1,5 +1,5 @@
 import { ConditionalOrderParams } from "@cowprotocol/cow-sdk";
-import { Config, FilterAction as FilterActionSchema } from "../types";
+import { Config, FilterAction as FilterActionSchema } from "../../../types";
 
 export enum FilterAction {
   DROP = "DROP",

--- a/src/domain/polling/poll.ts
+++ b/src/domain/polling/poll.ts
@@ -5,7 +5,7 @@ import {
   PollParams,
   PollResult,
 } from "@cowprotocol/cow-sdk";
-import { getLogger } from "./logging";
+import { getLogger } from "../../utils/logging";
 
 // Watch-tower will index every block, so we will by default the processing block and not the latest.
 const POLL_FROM_LATEST_BLOCK = false;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -2,11 +2,10 @@ import { Server } from "http";
 import express, { Request, Response, Router } from "express";
 import { Express } from "express-serve-static-core";
 import * as client from "prom-client";
-import { getLogger } from "./logging";
-import { DBService } from "./db";
+import { getLogger } from "../utils/logging";
+import { DBService, ChainContext } from "../services";
 import { Registry } from "../types";
 import { version, name, description } from "../../package.json";
-import { ChainContext } from "../domain";
 
 export class ApiService {
   protected port: number;

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -14,18 +14,18 @@ import {
   OrderBookApi,
   ApiBaseUrls,
 } from "@cowprotocol/cow-sdk";
-import { addContract } from "./addContract";
-import { checkForAndPlaceOrder } from "./checkForAndPlaceOrder";
+import { addContract } from "../domain/events";
+import { checkForAndPlaceOrder } from "../domain/polling";
 import { EventFilter, providers } from "ethers";
 import {
   composableCowContract,
-  DBService,
   getLogger,
   isRunningInKubernetesPod,
   metrics,
 } from "../utils";
+import { DBService } from ".";
 import { hexZeroPad } from "ethers/lib/utils";
-import { FilterPolicy } from "../utils/filterPolicy";
+import { policy } from "../domain/polling/filtering";
 
 const WATCHDOG_FREQUENCY_SECS = 5; // 5 seconds
 const WATCHDOG_TIMEOUT_DEFAULT_SECS = 30;
@@ -86,7 +86,7 @@ export class ChainContext {
   chainId: SupportedChainId;
   registry: Registry;
   orderBook: OrderBookApi;
-  filterPolicy: FilterPolicy | undefined;
+  filterPolicy: policy.FilterPolicy | undefined;
   contract: ComposableCoW;
   multicall: Multicall3;
 
@@ -129,7 +129,7 @@ export class ChainContext {
       },
     });
 
-    this.filterPolicy = new FilterPolicy(filterPolicy);
+    this.filterPolicy = new policy.FilterPolicy(filterPolicy);
     this.contract = composableCowContract(this.provider, this.chainId);
     this.multicall = Multicall3__factory.connect(MULTICALL3, this.provider);
   }

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,7 @@
+import { DBService } from "./storage";
+import { ApiService } from "./api";
+import { ChainContext, SDK_BACKOFF_NUM_OF_ATTEMPTS } from "./chain";
+
+// Exporting the `SDK_BACKOFF_NUM_OF_ATTEMPTS` is a smell that can be eliminated
+// when upstream (`cow-sdk`) allows passing instantiated `OrderBookApi` for `.poll`.
+export { DBService, ApiService, ChainContext, SDK_BACKOFF_NUM_OF_ATTEMPTS };

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,5 +1,5 @@
 import { DatabaseOptions, Level } from "level";
-import { getLogger } from "./logging";
+import { getLogger } from "../utils/logging";
 
 const DEFAULT_DB_LOCATION = "./database";
 

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -4,7 +4,8 @@ import { BytesLike, ethers } from "ethers";
 
 import type { ConditionalOrderCreatedEvent } from "./generated/ComposableCoW";
 import { ConditionalOrderParams, PollResult } from "@cowprotocol/cow-sdk";
-import { DBService, metrics } from "../utils";
+import { DBService } from "../services";
+import { metrics } from "../utils";
 
 // Standardise the storage key
 const LAST_NOTIFIED_ERROR_STORAGE_KEY = "LAST_NOTIFIED_ERROR";

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,5 +1,5 @@
 import Slack = require("node-slack");
-import { DBService } from "./db";
+import { DBService } from "../services";
 
 import { ContextOptions, ExecutionContext, Registry } from "../types";
 import { SupportedChainId } from "@cowprotocol/cow-sdk";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,8 +1,5 @@
 export * from "./context";
 export * from "./contracts";
-export * from "./poll";
 export * from "./misc";
-export * from "./db";
 export * from "./logging";
-export * from "./api";
 export * as metrics from "./metrics";


### PR DESCRIPTION
# Description

This PR refactors legacy locations of code to more accurately reflect the area of responsibility for the respective code.

# Changes

- [x] Any core "service" that is running is located within the "services" module.
- [x] Domain logic is split related to indexing ("events"), and polling ("polling")
- [x] Filtering that has been applied is made more meaningful and moved to a "filtering" module

## How to test
1. Verify that `yarn test` passes
2. Run from genesis on `mainnet` and verify the block watcher comes online (passes `warmUp`).