### PR TITLE
Add conditional order id to our model

### DIFF
--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -18,9 +18,9 @@ import {
   Proof,
   Registry,
 } from "../../types";
+import { ConditionalOrder, ConditionalOrderParams } from "@cowprotocol/cow-sdk";
 
 import { ChainContext } from "../../services/chain";
-import { ConditionalOrderParams } from "@cowprotocol/cow-sdk";
 
 /**
  * Listens to these events on the `ComposableCoW` contract:
@@ -201,6 +201,8 @@ export function add(
   const log = getLogger("addContract:add");
   const { handler, salt, staticInput } = params;
   const { network, ownerOrders } = registry;
+
+  const conditionalOrderId = ConditionalOrder.leafToId(params);
   if (ownerOrders.has(owner)) {
     const conditionalOrders = ownerOrders.get(owner);
     log.info(
@@ -220,6 +222,7 @@ export function add(
     // If the params are not in the conditionalOrder, add them
     if (!exists) {
       conditionalOrders?.add({
+        id: conditionalOrderId,
         tx,
         params: { handler, salt, staticInput },
         proof,
@@ -237,7 +240,16 @@ export function add(
     });
     registry.ownerOrders.set(
       owner,
-      new Set([{ tx, params, proof, orders: new Map(), composableCow }])
+      new Set([
+        {
+          id: conditionalOrderId,
+          tx,
+          params,
+          proof,
+          orders: new Map(),
+          composableCow,
+        },
+      ])
     );
     metrics.activeOwnersTotal.labels(network).inc();
     metrics.activeOrdersTotal.labels(network).inc();

--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -207,7 +207,7 @@ export function add(
     const conditionalOrders = ownerOrders.get(owner);
     log.info(
       `Adding conditional order to already existing owner contract ${owner}`,
-      { tx, handler, salt, staticInput }
+      { conditionalOrderId, tx, handler, salt, staticInput }
     );
     let exists = false;
     // Iterate over the conditionalOrders to make sure that the params are not already in the registry
@@ -233,6 +233,7 @@ export function add(
     }
   } else {
     log.info(`Adding conditional order to new owner contract ${owner}:`, {
+      conditionalOrderId,
       tx,
       handler,
       salt,

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -112,7 +112,7 @@ export async function checkForAndPlaceOrder(
         blockNumber.toString(),
         ownerRef
       );
-      const logOrderDetails = `Processing order from TX ${conditionalOrder.tx} with params:`;
+      const logOrderDetails = `Processing order ${conditionalOrder.id} from TX ${conditionalOrder.tx} with params:`;
 
       const { result: lastHint } = conditionalOrder.pollResult || {};
 
@@ -259,8 +259,12 @@ async function _processConditionalOrder(
     "checkForAndPlaceOrder:_processConditionalOrder",
     orderRef
   );
-  const id = ConditionalOrderSDK.leafToId(conditionalOrder.params);
-  const metricLabels = [chainId.toString(), handler, owner, id];
+  const metricLabels = [
+    chainId.toString(),
+    handler,
+    owner,
+    conditionalOrder.id,
+  ];
   try {
     metrics.pollingRunsTotal.labels(...metricLabels).inc();
 
@@ -289,6 +293,7 @@ async function _processConditionalOrder(
       },
     };
     let pollResult = await pollConditionalOrder(
+      conditionalOrder.id,
       pollParams,
       conditionalOrder.params,
       orderRef

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -201,12 +201,15 @@ export async function checkForAndPlaceOrder(
         (isError && pollResult.reason ? `. Reason: ${pollResult.reason}` : "");
 
       log[unexpectedError ? "error" : "info"](
-        `Check conditional order result: ${getEmojiByPollResult(
-          pollResult?.result
-        )} ${resultDescription}`
+        `Check conditional order result for ${
+          conditionalOrder.id
+        }: ${getEmojiByPollResult(pollResult?.result)} ${resultDescription}`
       );
       if (unexpectedError) {
-        log.error(`UNEXPECTED_ERROR Details:`, pollResult.error);
+        log.error(
+          `UNEXPECTED_ERROR for order ${conditionalOrder.id}. Details:`,
+          pollResult.error
+        );
       }
 
       hasErrors ||= unexpectedError;
@@ -217,7 +220,9 @@ export async function checkForAndPlaceOrder(
       const deleted = conditionalOrders.delete(conditionalOrder);
       const action = deleted ? "Stop Watching" : "Failed to stop watching";
 
-      log.debug(`${action} conditional order from TX ${conditionalOrder.tx}`);
+      log.debug(
+        `${action} conditional order ${conditionalOrder.id} from TX ${conditionalOrder.tx}`
+      );
       metrics.activeOrdersTotal.labels(chainId.toString()).dec();
     }
   }

--- a/src/domain/polling/poll.ts
+++ b/src/domain/polling/poll.ts
@@ -15,6 +15,7 @@ const ordersFactory = new ConditionalOrderFactory(
 );
 
 export async function pollConditionalOrder(
+  conditionalOrderId: string,
   pollParams: PollParams,
   conditionalOrderParams: ConditionalOrderParams,
   orderRef: string
@@ -30,7 +31,7 @@ export async function pollConditionalOrder(
     : pollParams;
 
   log.debug(
-    `Polling for ${order.toString()} using block (${
+    `Polling id ${conditionalOrderId}. Order ${order.toString()} using block (${
       actualPollParams.blockInfo === undefined
         ? "latest"
         : actualPollParams.blockInfo.blockNumber


### PR DESCRIPTION
# Description
Ths PR adds the conditional order ID to our mode.

As this is a breaking change, the PR also does some model migration (from version 1 to version 2).

Additionally, it adds some additional logging to print the conditional order ID which is convenient.