### PR TITLE
chore: bump cow-sdk and api errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@commander-js/extra-typings": "^11.0.0",
     "@cowprotocol/contracts": "^1.4.0",
-    "@cowprotocol/cow-sdk": "^5.0.1",
+    "@cowprotocol/cow-sdk": "^5.2.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "chalk": "^4.1.2",

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -53,7 +53,6 @@ type BackOffApiErrorsDelays = {
  * Handle error that will return `TRY_NEXT_BLOCK`, so it doesn't throw but is re-attempted on next block
  */
 const API_ERRORS_TRY_NEXT_BLOCK: NextBlockApiErrorsArray = [
-  ApiErrors.INSUFFICIENT_FEE,
   ApiErrors.QUOTE_NOT_FOUND,
   ApiErrors.INVALID_QUOTE,
   ApiErrors.INSUFFICIENT_VALID_TO,
@@ -66,7 +65,7 @@ const ONE_HOUR = 60 * 60;
 const API_ERRORS_BACKOFF: BackOffApiErrorsDelays = {
   [ApiErrors.INSUFFICIENT_ALLOWANCE]: TEN_MINS,
   [ApiErrors.INSUFFICIENT_BALANCE]: TEN_MINS,
-  TooManyLimitOrders: ONE_HOUR,
+  [ApiErrors.TOO_MANY_LIMIT_ORDERS]: ONE_HOUR,
   [ApiErrors.INVALID_APP_DATA]: ONE_MIN, // Give the user some time to upload the correct appData
 };
 
@@ -74,7 +73,8 @@ const API_ERRORS_DROP: DropApiErrorsArray = [
   ApiErrors.SELL_AMOUNT_OVERFLOW, // Implies a `feeAmount` has been set and `sellAmount` + `feeAmount` > `type(uint256).max`
   ApiErrors.TRANSFER_SIMULATION_FAILED, // Sell token can't be transferred, drop it
   ApiErrors.ZERO_AMOUNT, // Any order with zero amount indicates bad logic, drop it
-  "UnsupportedBuyTokenDestination",
+  ApiErrors.UNSUPPORTED_BUY_TOKEN_DESTINATION,
+  ApiErrors.TOO_MUCH_GAS, // Order is too large, likely some bad logic, drop it
   ApiErrors.UNSUPPORTED_SELL_TOKEN_SOURCE,
   ApiErrors.UNSUPPORTED_ORDER_TYPE,
   ApiErrors.EXCESSIVE_VALID_TO, // Order is too far in the future, likely some bad logic, drop it

--- a/yarn.lock
+++ b/yarn.lock
@@ -476,10 +476,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.4.0.tgz#e93e5f25aac76feeaa348fa57231903274676247"
   integrity sha512-XLs3SlPmXD4lbiWIO7mxxuCn1eE5isuO6EUlE1cj17HqN/wukDAN0xXYPx6umOH/XdjGS33miMiPHELEyY9siw==
 
-"@cowprotocol/cow-sdk@^5.0.1":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-5.1.0.tgz#df179c43bdf9d66d7134ac1290d26b6993fb5a1f"
-  integrity sha512-o1QTav1TWvNeI9UV8Gy3TPGVUFIWlLBSWcRGpxRvGy6ktWceIKK54VVLrh2mlRBbBvl3eH8jCYthj9cBbzECfg==
+"@cowprotocol/cow-sdk@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-5.2.0.tgz#f3ec621b579b4a9bf2e6fd3d695786f7c7978e56"
+  integrity sha512-7AWWEM4uyKDHyBoivAEkgULpI+mVZ4thMQXRM/CB8hW5MrnGxq6ONJECrq2k7uAiHrn9i2kdPjCwSPxKayVY8Q==
   dependencies:
     "@cowprotocol/contracts" "^1.4.0"
     "@ethersproject/abstract-signer" "^5.7.0"


### PR DESCRIPTION
# Description
Updates `cow-sdk` which contains changes related to the API errors that the watch-tower may encounter.

# Changes

- [x] Fix errors so that those that weren't generated by the open api generator previously are handled idiomatically.
- [x] Adds error handling for new type `TooMuchGas` - likely to be encountered when there is a bad order type that is far too inefficient for gas settlement.

## How to test
1. Verify that API errors are used from generated code.