### PR TITLE
feat: improve first sync

### DIFF
--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -244,7 +244,7 @@ export class ChainContext {
         // Process blocks in order
         for (const blockNumberKey of Object.keys(eventsByBlock).sort()) {
           const blockNumber = Number(blockNumberKey);
-          lastProcessedBlock = await processBlockAndPersist({
+          await processBlockAndPersist({
             context: this,
             blockNumber,
             events: eventsByBlock[blockNumber],

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -2,7 +2,6 @@ import Slack = require("node-slack");
 
 import { BytesLike, ethers } from "ethers";
 
-import type { ConditionalOrderCreatedEvent } from "./generated/ComposableCoW";
 import { ConditionalOrderParams, PollResult } from "@cowprotocol/cow-sdk";
 import { DBService } from "../services";
 import { metrics } from "../utils";
@@ -25,11 +24,6 @@ export interface ExecutionContext {
   notificationsEnabled: boolean;
   slack?: Slack;
   storage: DBService;
-}
-
-// Todo: This should also encompass `MerkleRootSet`
-export interface ReplayPlan {
-  [key: number]: Set<ConditionalOrderCreatedEvent>;
 }
 
 /**


### PR DESCRIPTION
# Description
This PR is an attempt to improve the first sync for watch-tower

## Context: Before this PR
The issue with the current model is that
1) It enter SYNC mode
2) In SYNC mode it will check all pending blocks from last processed until the tip of the blockchains
- Instead of actually processing the blocks, its just "saving" the block for processing later (its creating a sync plan)
3) Once in SYNC, it will apply the plan
- This time it will process for real the blocks

The issues we experience is becasue between 2 and 3 there's a delay and the metric of "blocks processed" goes down. Thats our main metric.

The solution is to not make a plan and process blocks as we find them instead of  waiting to be fully catched up.

## Proposed solution
I just refactored the 2 points where we do the processing of blocks (applying the plan, and when watching for new blocks). 

Now I use an auxiliary function that will process the block, update the metrics, and persist in the database. 

This should help in several ways:
- We will improve the metric of "blocks processed". This metric is key for our alerts. We don't want to be notified if during a restart watchtower needs some time to consume all pending blocks
- Additionally should help with very big syncs, like first syncs or big downtimes. Before this PR it was indexing all blocks before processing any block. This approach should be better because in case of a crash, next run will resume the work where it left it.
- Derived from the item above, I suspect the memory issues could be related to applying a big plan when the pod restarts

## Test
I haven't tested this much and is very sensitive change. I would love to get some feedback first, then I'd like to test it in staging.  


I just did a minimal test of running it in Arbitrum locally:

<img width="1429" alt="image" src="https://github.com/cowprotocol/watch-tower/assets/2352112/362d997e-c17b-458b-be79-ce309986c433">


The watch-tower arrived to a SYNC state and processed blocks as it found them:
<img width="1089" alt="image" src="https://github.com/cowprotocol/watch-tower/assets/2352112/93cfa98f-faa8-4e1d-9157-0644159abaff">
