### PR TITLE
fix: fix issue with broken metric

### DIFF
--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -504,7 +504,7 @@ async function persistLastProcessedBlock(params: {
   log.debug(`Block ${blockNumber} has been processed`);
 
   // Set the block height metric
-  metrics.blockHeight.labels(context.toString()).set(blockNumber);
+  metrics.blockHeight.labels(context.chainId.toString()).set(blockNumber);
 
   return context.registry.lastProcessedBlock;
 }


### PR DESCRIPTION
# Description
I found the issue here.

It was just a bad parameter for prometheus metric

<img width="770" alt="Screenshot at Jun 25 18-09-44" src="https://github.com/cowprotocol/watch-tower/assets/2352112/39447e3d-a13d-48c6-8a36-40091b1d75e9">

Now is good, see:

<img width="738" alt="image" src="https://github.com/cowprotocol/watch-tower/assets/2352112/0f1eb58f-319f-4215-87a6-6760c4d428f6">


## Context
https://cowservices.slack.com/archives/C0361CDD1FZ/p1719303401299659

## Test
Run this locally and observe `watch_tower_block_height` metric exposed in http://localhost:8080/metrics