### PR TITLE
Fix Example Configuration File

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -5,18 +5,18 @@
             "rpc": "ws://172.20.0.5:8546",
             "deploymentBlock": 17883049,
             "filterPolicy": {
-                "defaultAction": "ACCEPT",                
+                "defaultAction": "ACCEPT",
                 "conditionalOrderIds": {
-                  "0x5b3cdb6ffa3c95507cbfc459162609007865c2e87340312d3cd469c4ffbfae81": "DROP",
+                  "0x5b3cdb6ffa3c95507cbfc459162609007865c2e87340312d3cd469c4ffbfae81": "DROP"
                 },
                 "transactions": {
-                  "0x33ef06af308d1e4f94dd61fa8df43fe52b67e8a485f4e4fff75235080e663bfa": "DROP",
+                  "0x33ef06af308d1e4f94dd61fa8df43fe52b67e8a485f4e4fff75235080e663bfa": "DROP"
                 },
                 "handlers": {
-                  "0xd3338f21c89745e46af56aeaf553cf96ba9bc66f": "DROP",
+                  "0xd3338f21c89745e46af56aeaf553cf96ba9bc66f": "DROP"
                 },
                 "owners": {
-                  "0xd3338f21c89745e46af56aeaf553cf96ba9bc66f": "DROP",
+                  "0xd3338f21c89745e46af56aeaf553cf96ba9bc66f": "DROP"
                 }
             }
         }


### PR DESCRIPTION
# Description

When running with the example configuration file, you get the following error:

```
Error parsing configuration file: SyntaxError: Expected double-quoted property name in JSON at position 387 (line 11 column 17)
    at JSON.parse (<anonymous>)
    at validateJSON (/usr/src/app/dist/src/index.js:122:27)
    at Command.<anonymous> (/usr/src/app/dist/src/index.js:65:24)
    at Command.listener [as _actionHandler] (/usr/src/app/node_modules/commander/lib/command.js:482:17)
    at /usr/src/app/node_modules/commander/lib/command.js:1300:65
    at Command._chainOrCall (/usr/src/app/node_modules/commander/lib/command.js:1197:12)
    at Command._parseCommand (/usr/src/app/node_modules/commander/lib/command.js:1300:27)
    at /usr/src/app/node_modules/commander/lib/command.js:1081:27
    at Command._chainOrCall (/usr/src/app/node_modules/commander/lib/command.js:1197:12)
    at Command._dispatchSubcommand (/usr/src/app/node_modules/commander/lib/command.js:1077:23)
```

It appears that it doesn't like the trailing `,`s (so it appears to only support plain old JSON and not JSONc or JSON5).

# Changes

This PR fixes the example configuration file to be valid JSON (and also removes some trailing whitespace in the file).

## How to test

1. Run the Docker image with the [instructions from the README](https://github.com/cowprotocol/watch-tower?tab=readme-ov-file#docker) and see no more error.