### PR TITLE
fix: save orders more often

### DIFF
--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -8,13 +8,6 @@ import {
 import { ethers } from "ethers";
 import { BytesLike } from "ethers/lib/utils";
 
-import { ConditionalOrder, OrderStatus } from "../../types";
-import {
-  formatStatus,
-  getLogger,
-  handleOnChainCustomError,
-  metrics,
-} from "../../utils";
 import {
   ConditionalOrder as ConditionalOrderSDK,
   OrderBookApi,
@@ -30,6 +23,13 @@ import {
   formatEpoch,
 } from "@cowprotocol/cow-sdk";
 import { ChainContext } from "../../services";
+import { ConditionalOrder, OrderStatus } from "../../types";
+import {
+  formatStatus,
+  getLogger,
+  handleOnChainCustomError,
+  metrics,
+} from "../../utils";
 import { badOrder, policy } from "./filtering";
 import { pollConditionalOrder } from "./poll";
 

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -513,7 +513,7 @@ async function _placeOrder(params: {
 
     // If the operation is a dry run, don't post to the API
     log.info(`Post order ${orderUid} to OrderBook on chain ${chainId}`);
-    log.debug(`Post order details`, postOrder);
+    log.debug(`Post order ${orderUid} details`, postOrder);
     if (!dryRun) {
       const orderUid = await orderBookApi.sendOrder(postOrder);
       metrics.orderBookDiscreteOrdersTotal.labels(...metricLabels).inc();

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -153,13 +153,7 @@ export async function checkForAndPlaceOrder(
       }
 
       const ownerRef = `${ownerCounter}.${orderCounter}`;
-      const orderRef = `${chainId}:${ownerRef}@${blockNumber}`;
-      const log = getLogger(
-        "checkForAndPlaceOrder:checkForAndPlaceOrder",
-        chainId.toString(),
-        blockNumber.toString(),
-        ownerRef
-      );
+      const orderRef = `${chainId}:${blockNumber}:${ownerRef}`;
       const logOrderDetails = `Processing order ${conditionalOrder.id} from TX ${conditionalOrder.tx} with params:`;
 
       const { result: lastHint } = conditionalOrder.pollResult || {};

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -295,7 +295,7 @@ export class ChainContext {
         oneShot ? "Chain watcher is in sync" : "Chain watcher is warmed up"
       }`
     );
-    log.debug(`Last processed block: ${lastProcessedBlock}`);
+    log.debug(`Last processed block: ${JSON.stringify(lastProcessedBlock)}`);
 
     // If one-shot, return
     if (oneShot) {
@@ -591,10 +591,14 @@ function _formatResult(result: boolean) {
 }
 
 function getProvider(rpcUrl: string): providers.Provider {
+  const log = getLogger("getProvider", rpcUrl);
   // if the rpcUrl is a websocket url, use the WebSocketProvider
   if (rpcUrl.startsWith("ws")) {
+    log.debug("Instantiating WS");
     return new providers.WebSocketProvider(rpcUrl);
   }
+
+  log.debug("Instantiating HTTP");
 
   // otherwise, use the JsonRpcProvider
   return new providers.JsonRpcProvider(rpcUrl);

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -1,21 +1,23 @@
 import {
-  Registry,
-  ConditionalOrderCreatedEvent,
-  Multicall3,
-  ComposableCoW,
-  Multicall3__factory,
-  RegistryBlock,
-  blockToRegistryBlock,
-  ContextOptions,
-} from "../types";
-import {
-  SupportedChainId,
-  OrderBookApi,
   ApiBaseUrls,
+  OrderBookApi,
+  SupportedChainId,
 } from "@cowprotocol/cow-sdk";
+import { ethers, providers } from "ethers";
+import { DBService } from ".";
 import { addContract } from "../domain/events";
 import { checkForAndPlaceOrder } from "../domain/polling";
-import { ethers, providers } from "ethers";
+import { policy } from "../domain/polling/filtering";
+import {
+  ComposableCoW,
+  ConditionalOrderCreatedEvent,
+  ContextOptions,
+  Multicall3,
+  Multicall3__factory,
+  Registry,
+  RegistryBlock,
+  blockToRegistryBlock,
+} from "../types";
 import {
   LoggerWithMethods,
   composableCowContract,
@@ -23,8 +25,6 @@ import {
   isRunningInKubernetesPod,
   metrics,
 } from "../utils";
-import { DBService } from ".";
-import { policy } from "../domain/polling/filtering";
 
 const WATCHDOG_FREQUENCY_SECS = 5; // 5 seconds
 const WATCHDOG_TIMEOUT_DEFAULT_SECS = 30;

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -28,6 +28,8 @@ export class DBService {
   }
 
   public async open() {
+    const log = getLogger("dbService:open");
+    log.info("Opening database...");
     await this.db.open();
   }
 

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -2,10 +2,13 @@ import Slack = require("node-slack");
 
 import { BytesLike, ethers } from "ethers";
 
-import { ConditionalOrderParams, PollResult } from "@cowprotocol/cow-sdk";
+import {
+  ConditionalOrderParams,
+  ConditionalOrder as ConditionalOrderSdk,
+  PollResult,
+} from "@cowprotocol/cow-sdk";
 import { DBService } from "../services";
-import { metrics } from "../utils";
-import { ConditionalOrder as ConditionalOrderSdk } from "@cowprotocol/cow-sdk";
+import { getLogger, metrics } from "../utils";
 
 // Standardise the storage key
 const LAST_NOTIFIED_ERROR_STORAGE_KEY = "LAST_NOTIFIED_ERROR";
@@ -237,6 +240,14 @@ export class Registry {
 
     // Write all atomically
     await batch.write();
+
+    const log = getLogger(
+      `Registry:write:${this.version}:${this.network}:${
+        this.lastProcessedBlock?.number
+      }:${this.lastNotifiedError || ""}`
+    );
+
+    log.debug("batch written 📝");
   }
 
   public stringifyOrders(): string {

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -14,7 +14,7 @@ export interface Config {
     deploymentBlock: number;
     watchdogTimeout?: number;
     /**
-     * Throttle block processing to only process blocks every N blocks. Set to 1 to process every block, 2 to process every other block, etc.
+     * Throttle block processing to only process blocks every N blocks. Set to 1 to process every block (default), 2 to process every other block, etc.
      */
     processEveryNumBlocks?: number;
     orderBookApi?: string;


### PR DESCRIPTION
# Description

This PR introduces more often saving of orders after processing.
For now, after every 20 orders processed, it'll trigger a db save.

There are also some logging improvements to make debugging easier.

## How to test

Run the service.
It should start and process orders as usual.

## Related Issues

There have been performance issues which I'm not able to tell what's causing it so far.
This change is an attempt to alleviate the in memory load by saving it more often.