### PR TITLE
fix: attempt to fix memory leak

### DIFF
--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -293,7 +293,8 @@ function _deleteOrders(
   log: LoggerWithMethods,
   chainId: SupportedChainId
 ) {
-  log.debug(`${ordersPendingDelete.length} to delete`);
+  ordersPendingDelete.length &&
+    log.debug(`${ordersPendingDelete.length} to delete`);
 
   for (const conditionalOrder of ordersPendingDelete) {
     const deleted = conditionalOrders.delete(conditionalOrder);

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -266,7 +266,7 @@ export async function checkForAndPlaceOrder(
 
   // It may be handy in other versions of the watch tower implemented in other languages
   // to not delete owners, so we can keep track of them.
-  for (const [owner, conditionalOrders] of Array.from(ownerOrders.entries())) {
+  for (const [owner, conditionalOrders] of ownerOrders) {
     if (conditionalOrders.size === 0) {
       ownerOrders.delete(owner);
       metrics.activeOwnersTotal.labels(chainId.toString()).dec();

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -583,7 +583,7 @@ async function pollContractForEvents(
         event.topics
       ) as unknown as ConditionalOrderCreatedEvent;
 
-      if (addresses ? addresses.includes(decoded.args.owner) : true) {
+      if (!addresses || addresses.includes(decoded.args.owner)) {
         acc.push({
           ...decoded,
           ...event,

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -106,6 +106,7 @@ export class Registry {
   network: string;
   lastNotifiedError: Date | null;
   lastProcessedBlock: RegistryBlock | null;
+  readonly logger = getLogger("Registry");
 
   /**
    * Instantiates a registry.
@@ -245,13 +246,12 @@ export class Registry {
     // Write all atomically
     await batch.write();
 
-    const log = getLogger(
-      `Registry:write:${this.version}:${this.network}:${
+    this.logger.debug(
+      `write:${this.version}:${this.network}:${
         this.lastProcessedBlock?.number
-      }:${this.lastNotifiedError || ""}`
+      }:${this.lastNotifiedError || ""}`,
+      "batch written 📝"
     );
-
-    log.debug("batch written 📝");
   }
 
   public stringifyOrders(): string {

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -189,7 +189,11 @@ export class Registry {
   }
 
   get numOrders(): number {
-    return Array.from(this.ownerOrders.values()).flatMap((o) => o).length;
+    let count = 0;
+    for (const orders of this.ownerOrders.values()) {
+      count += orders.size; // Count each set's size directly
+    }
+    return count;
   }
 
   /**

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -304,9 +304,7 @@ async function loadOwnerOrders(
   );
 
   // Parse conditional orders registry (for the persisted version, converting it to the last version)
-  const ownerOrders = parseConditionalOrders(!!str ? str : undefined, version);
-
-  return ownerOrders;
+  return parseConditionalOrders(!!str ? str : undefined, version);
 }
 
 function parseConditionalOrders(


### PR DESCRIPTION
# Description

I noticed that since my last changes #159 and #160 , there has been a very visible memory leak, specially on arb1.
![image](https://github.com/user-attachments/assets/f447e5dd-c503-4eed-bce9-3c50771bdcbd)

[graph link](https://g-0263500beb.grafana-workspace.eu-central-1.amazonaws.com/goto/sjeXFwkHg?orgId=1)

While I have not been able to detect where the memory leak is, this PR has several improvements that might help.

# Changes

- [x] Remove a couple of unnecessary Array conversions, using iterators instead
- [x] Use a single logger instance in the Registry class
- [x] Move block skipping logic early, avoiding unnecessary RPC calls
- [x] Reuse `block` instance if already queried

## How to test
Run it locally: should work
![image](https://github.com/user-attachments/assets/f2583ed1-4ebf-4d20-a53d-86824d7c7ac2)

~I'll also run it on staging for awhile before taking this PR out of draft.~ can't apply it, pulumi is not happy with me.