### PR TITLE
chore: add more logs for OOM search

### DIFF
--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -10,7 +10,6 @@ import { BytesLike, ethers } from "ethers";
 import {
   ComposableCoW,
   ComposableCoW__factory,
-  ComposableCoWInterface,
   ConditionalOrderCreatedEvent,
   IConditionalOrder,
   MerkleRootSetEvent,
@@ -21,6 +20,8 @@ import {
 import { ConditionalOrder, ConditionalOrderParams } from "@cowprotocol/cow-sdk";
 
 import { ChainContext } from "../../services/chain";
+
+const composableCow = ComposableCoW__factory.createInterface();
 
 /**
  * Listens to these events on the `ComposableCoW` contract:
@@ -48,7 +49,6 @@ async function _addContract(
   context: ChainContext,
   event: ConditionalOrderCreatedEvent
 ) {
-  const composableCow = ComposableCoW__factory.createInterface();
   const log = getLogger("addContract:_addContract");
   const { registry } = context;
   const { transactionHash: tx, blockNumber } = event;
@@ -57,11 +57,7 @@ async function _addContract(
   let hasErrors = false;
   let numContractsAdded = 0;
 
-  const { error, added } = await registerNewOrder(
-    event,
-    composableCow,
-    registry
-  );
+  const { error, added } = await registerNewOrder(event, registry);
 
   if (added) {
     metrics.ownersTotal.labels(context.chainId.toString()).inc();
@@ -91,7 +87,6 @@ async function _addContract(
 
 async function registerNewOrder(
   event: ConditionalOrderCreatedEvent | MerkleRootSetEvent,
-  composableCow: ComposableCoWInterface,
   registry: Registry
 ): Promise<{ error: boolean; added: boolean }> {
   const log = getLogger("addContract:registerNewOrder");

--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -216,6 +216,7 @@ function add(
         const areConditionalOrderParamsEqual =
           getAreConditionalOrderParamsEqual(conditionalOrder.params, params);
 
+        // TODO: delete this log after testing
         if (
           areConditionalOrderParamsEqual &&
           conditionalOrder.params !== params

--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -22,9 +22,6 @@ import { ConditionalOrder, ConditionalOrderParams } from "@cowprotocol/cow-sdk";
 
 import { ChainContext } from "../../services/chain";
 
-const composableCow = ComposableCoW__factory.createInterface();
-const log = getLogger("addContract:_addContract");
-
 /**
  * Listens to these events on the `ComposableCoW` contract:
  * - `ConditionalOrderCreated`
@@ -51,6 +48,8 @@ async function _addContract(
   context: ChainContext,
   event: ConditionalOrderCreatedEvent
 ) {
+  const composableCow = ComposableCoW__factory.createInterface();
+  const log = getLogger("addContract:_addContract");
   const { registry } = context;
   const { transactionHash: tx, blockNumber } = event;
 

--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -264,8 +264,8 @@ function add(
       ])
     );
 
-    // One increment owners and one orders
-    metrics.activeOwnersTotal.labels(network).inc(2);
+    metrics.activeOwnersTotal.labels(network).inc();
+    metrics.activeOrdersTotal.labels(network).inc();
   }
 }
 

--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -269,9 +269,8 @@ function add(
         },
       ])
     );
-    // TODO: why twice?
-    metrics.activeOwnersTotal.labels(network).inc();
-    metrics.activeOrdersTotal.labels(network).inc();
+
+    metrics.activeOwnersTotal.labels(network).inc(2);
   }
 }
 

--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -270,6 +270,7 @@ function add(
       ])
     );
 
+    // One increment owners and one orders
     metrics.activeOwnersTotal.labels(network).inc(2);
   }
 }

--- a/src/domain/events/index.ts
+++ b/src/domain/events/index.ts
@@ -1,18 +1,19 @@
 import {
-  toConditionalOrderParams,
+  getAreConditionalOrderParamsEqual,
   getLogger,
   handleExecutionError,
   metrics,
+  toConditionalOrderParams,
 } from "../../utils";
 import { BytesLike, ethers } from "ethers";
 
 import {
   ComposableCoW,
+  ComposableCoW__factory,
   ComposableCoWInterface,
   ConditionalOrderCreatedEvent,
   IConditionalOrder,
   MerkleRootSetEvent,
-  ComposableCoW__factory,
   Owner,
   Proof,
   Registry,
@@ -20,6 +21,9 @@ import {
 import { ConditionalOrder, ConditionalOrderParams } from "@cowprotocol/cow-sdk";
 
 import { ChainContext } from "../../services/chain";
+
+const composableCow = ComposableCoW__factory.createInterface();
+const log = getLogger("addContract:_addContract");
 
 /**
  * Listens to these events on the `ComposableCoW` contract:
@@ -47,8 +51,6 @@ async function _addContract(
   context: ChainContext,
   event: ConditionalOrderCreatedEvent
 ) {
-  const log = getLogger("addContract:_addContract");
-  const composableCow = ComposableCoW__factory.createInterface();
   const { registry } = context;
   const { transactionHash: tx, blockNumber } = event;
 
@@ -56,11 +58,12 @@ async function _addContract(
   let hasErrors = false;
   let numContractsAdded = 0;
 
-  const { error, added } = await _registerNewOrder(
+  const { error, added } = await registerNewOrder(
     event,
     composableCow,
     registry
   );
+
   if (added) {
     metrics.ownersTotal.labels(context.chainId.toString()).inc();
     numContractsAdded++;
@@ -69,6 +72,7 @@ async function _addContract(
       `Failed to register Smart Order from tx ${tx} on block ${blockNumber}. Error: ${error}`
     );
   }
+
   hasErrors ||= error;
 
   if (numContractsAdded > 0) {
@@ -86,15 +90,16 @@ async function _addContract(
   }
 }
 
-export async function _registerNewOrder(
+async function registerNewOrder(
   event: ConditionalOrderCreatedEvent | MerkleRootSetEvent,
   composableCow: ComposableCoWInterface,
   registry: Registry
 ): Promise<{ error: boolean; added: boolean }> {
-  const log = getLogger("addContract:_registerNewOrder");
+  const log = getLogger("addContract:registerNewOrder");
   const { transactionHash: tx } = event;
   const { network } = registry;
   let added = false;
+
   try {
     // Check if the log is a ConditionalOrderCreated event
     if (
@@ -177,13 +182,14 @@ export async function _registerNewOrder(
 /**
  * Attempt to add an owner's conditional order to the registry
  *
+ * @param tx transaction that created the conditional order
  * @param owner to add the conditional order to
  * @param params for the conditional order
  * @param proof for the conditional order (if it is part of a merkle root)
  * @param composableCow address of the contract that emitted the event
  * @param registry of all conditional orders
  */
-export function add(
+function add(
   tx: string,
   owner: Owner,
   params: ConditionalOrderParams,
@@ -206,6 +212,23 @@ export function add(
     // Iterate over the conditionalOrders to make sure that the params are not already in the registry
     for (const conditionalOrder of conditionalOrders?.values() ?? []) {
       // Check if the params are in the conditionalOrder
+      if (conditionalOrder) {
+        const areConditionalOrderParamsEqual =
+          getAreConditionalOrderParamsEqual(conditionalOrder.params, params);
+
+        if (
+          areConditionalOrderParamsEqual &&
+          conditionalOrder.params !== params
+        ) {
+          log.error(
+            "Conditional order params are equal but not the same",
+            conditionalOrder.id,
+            JSON.stringify(params)
+          );
+        }
+      }
+
+      // TODO: this is a shallow comparison, should we do a deep comparison?
       if (conditionalOrder.params === params) {
         exists = true;
         break;
@@ -245,6 +268,7 @@ export function add(
         },
       ])
     );
+    // TODO: why twice?
     metrics.activeOwnersTotal.labels(network).inc();
     metrics.activeOrdersTotal.labels(network).inc();
   }
@@ -256,19 +280,20 @@ export function add(
  * @param root the merkle root to check against
  * @param registry of all conditional orders
  */
-export function flush(owner: Owner, root: BytesLike, registry: Registry) {
-  if (registry.ownerOrders.has(owner)) {
-    const conditionalOrders = registry.ownerOrders.get(owner);
-    if (conditionalOrders !== undefined) {
-      for (const conditionalOrder of conditionalOrders.values()) {
-        if (
-          conditionalOrder.proof !== null &&
-          conditionalOrder.proof.merkleRoot !== root
-        ) {
-          // Delete the conditional order
-          conditionalOrders.delete(conditionalOrder);
-        }
-      }
+function flush(owner: Owner, root: BytesLike, registry: Registry) {
+  if (!registry.ownerOrders.has(owner)) return;
+
+  const conditionalOrders = registry.ownerOrders.get(owner);
+
+  if (conditionalOrders === undefined) return;
+
+  for (const conditionalOrder of conditionalOrders.values()) {
+    if (
+      conditionalOrder.proof !== null &&
+      conditionalOrder.proof.merkleRoot !== root
+    ) {
+      // Delete the conditional order
+      conditionalOrders.delete(conditionalOrder);
     }
   }
 }

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -16,7 +16,6 @@ import {
   Multicall3__factory,
   Registry,
   RegistryBlock,
-  blockToRegistryBlock,
 } from "../types";
 import {
   LoggerWithMethods,
@@ -32,7 +31,7 @@ const WATCHDOG_TIMEOUT_DEFAULT_SECS = 30;
 const MULTICALL3 = "0xcA11bde05977b3631167028862bE2a173976CA11";
 const PAGE_SIZE_DEFAULT = 5000;
 
-export const SDK_BACKOFF_NUM_OF_ATTEMPTS = 5;
+const SDK_BACKOFF_NUM_OF_ATTEMPTS = 5;
 
 enum ChainSync {
   /** The chain is currently in the warm-up phase, synchronising from contract genesis or lastBlockProcessed */
@@ -459,6 +458,7 @@ async function processBlock(
   let hasErrors = false;
   for (const event of events) {
     const receipt = await provider.getTransactionReceipt(event.transactionHash);
+
     if (receipt) {
       // run action
       log.debug(`Running "addContract" action for TX ${event.transactionHash}`);
@@ -613,4 +613,12 @@ function getProvider(rpcUrl: string): providers.Provider {
 
 async function asyncSleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function blockToRegistryBlock(block: ethers.providers.Block): RegistryBlock {
+  return {
+    number: block.number,
+    timestamp: block.timestamp,
+    hash: block.hash,
+  };
 }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -1,10 +1,10 @@
 import Slack = require("node-slack");
 
-import { BytesLike, ethers } from "ethers";
+import { BytesLike } from "ethers";
 
 import {
-  ConditionalOrderParams,
   ConditionalOrder as ConditionalOrderSdk,
+  ConditionalOrderParams,
   PollResult,
 } from "@cowprotocol/cow-sdk";
 import { DBService } from "../services";
@@ -41,6 +41,7 @@ export type Proof = {
 
 export type OrderUid = BytesLike;
 export type Owner = string;
+
 export enum OrderStatus {
   SUBMITTED = 1,
   FILLED = 2,
@@ -95,27 +96,32 @@ export interface RegistryBlock {
   hash: string;
 }
 
+type OrdersPerOwner = Map<Owner, Set<ConditionalOrder>>;
+
+const logger = getLogger("Registry");
+
 /**
  * Models the state between executions.
  * Contains a map of owners to conditional orders and the last time we sent an error.
  */
 export class Registry {
   version = CONDITIONAL_ORDER_REGISTRY_VERSION;
-  ownerOrders: Map<Owner, Set<ConditionalOrder>>;
+  ownerOrders: OrdersPerOwner;
   storage: DBService;
   network: string;
   lastNotifiedError: Date | null;
   lastProcessedBlock: RegistryBlock | null;
-  readonly logger = getLogger("Registry");
 
   /**
    * Instantiates a registry.
    * @param ownerOrders What map to populate the registry with
    * @param storage storage service to use
    * @param network Which network the registry is for
+   * @param lastNotifiedError The last time we sent an error
+   * @param lastProcessedBlock The last block we processed
    */
   constructor(
-    ownerOrders: Map<Owner, Set<ConditionalOrder>>,
+    ownerOrders: OrdersPerOwner,
     storage: DBService,
     network: string,
     lastNotifiedError: Date | null,
@@ -144,8 +150,9 @@ export class Registry {
 
   /**
    * Load the registry from storage.
-   * @param context from which to load the registry
+   * @param storage to load the registry from
    * @param network that the registry is for
+   * @param genesisBlockNumber the block number of the genesis block
    * @returns a registry instance
    */
   public static async load(
@@ -154,9 +161,14 @@ export class Registry {
     genesisBlockNumber: number
   ): Promise<Registry> {
     const db = storage.getDB();
-    const ownerOrders = await loadOwnerOrders(storage, network).catch(() =>
-      createNewOrderMap()
+    const ownerOrders = await loadOwnerOrders(storage, network).catch(
+      (error) => {
+        logger.error("Error loading owner orders", error);
+
+        return createNewOrderMap();
+      }
     );
+
     const lastNotifiedError = await db
       .get(getNetworkStorageKey(LAST_NOTIFIED_ERROR_STORAGE_KEY, network))
       .then((isoDate: string | number | Date) =>
@@ -190,11 +202,7 @@ export class Registry {
   }
 
   get numOrders(): number {
-    let count = 0;
-    for (const orders of this.ownerOrders.values()) {
-      count += orders.size; // Count each set's size directly
-    }
-    return count;
+    return getOrdersCountFromOrdersPerOwner(this.ownerOrders);
   }
 
   /**
@@ -246,7 +254,7 @@ export class Registry {
     // Write all atomically
     await batch.write();
 
-    this.logger.debug(
+    logger.debug(
       `write:${this.version}:${this.network}:${
         this.lastProcessedBlock?.number
       }:${this.lastNotifiedError || ""}`,
@@ -259,7 +267,7 @@ export class Registry {
   }
 }
 
-export function _reviver(_key: any, value: any) {
+function reviver(_key: any, value: any) {
   if (typeof value === "object" && value !== null) {
     if (value.dataType === "Map") {
       return new Map(value.value);
@@ -270,7 +278,7 @@ export function _reviver(_key: any, value: any) {
   return value;
 }
 
-export function replacer(_key: any, value: any) {
+function replacer(_key: any, value: any) {
   if (value instanceof Map) {
     return {
       dataType: "Map",
@@ -289,7 +297,7 @@ export function replacer(_key: any, value: any) {
 async function loadOwnerOrders(
   storage: DBService,
   network: string
-): Promise<Map<string, Set<ConditionalOrder>>> {
+): Promise<OrdersPerOwner> {
   // Get the owner orders
   const db = storage.getDB();
   const str = await db.get(
@@ -304,20 +312,34 @@ async function loadOwnerOrders(
   );
 
   // Parse conditional orders registry (for the persisted version, converting it to the last version)
-  return parseConditionalOrders(!!str ? str : undefined, version);
+  const ordersPerOwner = parseConditionalOrders(
+    !!str ? str : undefined,
+    version
+  );
+
+  logger.info(
+    "[loadOwnerOrders]",
+    `Data size: ${str?.length}`,
+    `Owners: ${ordersPerOwner.size}`,
+    `Total orders: ${getOrdersCountFromOrdersPerOwner(ordersPerOwner)}`,
+    `Network: ${network}`
+  );
+
+  return ordersPerOwner;
 }
 
 function parseConditionalOrders(
   serializedConditionalOrders: string | undefined,
   _version: number | undefined
-): Map<Owner, Set<ConditionalOrder>> {
+): OrdersPerOwner {
   if (!serializedConditionalOrders) {
     return createNewOrderMap();
   }
+
   const ownerOrders: Map<
     Owner,
     Set<Omit<ConditionalOrder, "id"> & { id?: string }>
-  > = JSON.parse(serializedConditionalOrders, _reviver);
+  > = JSON.parse(serializedConditionalOrders, reviver);
 
   // The conditional order id was added in version 2
   if (_version && _version < 2) {
@@ -331,19 +353,21 @@ function parseConditionalOrders(
     }
   }
 
-  return ownerOrders as Map<Owner, Set<ConditionalOrder>>;
+  return ownerOrders as OrdersPerOwner;
 }
 
-function createNewOrderMap(): Map<Owner, Set<ConditionalOrder>> {
+function createNewOrderMap(): OrdersPerOwner {
   return new Map<Owner, Set<ConditionalOrder>>();
 }
 
-export function blockToRegistryBlock(
-  block: ethers.providers.Block
-): RegistryBlock {
-  return {
-    number: block.number,
-    timestamp: block.timestamp,
-    hash: block.hash,
-  };
+function getOrdersCountFromOrdersPerOwner(
+  ordersPerOwner: OrdersPerOwner
+): number {
+  let ordersCount = 0;
+
+  for (const orders of ordersPerOwner.values()) {
+    ordersCount += orders.size;
+  }
+
+  return ordersCount;
 }

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -31,3 +31,14 @@ export function toConditionalOrderParams({
     staticInput: staticInput.toString(),
   };
 }
+
+export function getAreConditionalOrderParamsEqual(
+  a: ConditionalOrderParams,
+  b: ConditionalOrderParams
+): boolean {
+  return (
+    a.handler === b.handler &&
+    a.salt === b.salt &&
+    a.staticInput === b.staticInput
+  );
+}

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -37,8 +37,8 @@ export function getAreConditionalOrderParamsEqual(
   b: ConditionalOrderParams
 ): boolean {
   return (
-    a.handler === b.handler &&
-    a.salt === b.salt &&
-    a.staticInput === b.staticInput
+    a.handler.toLowerCase() === b.handler.toLowerCase() &&
+    a.salt.toLowerCase() === b.salt.toLowerCase() &&
+    a.staticInput.toLowerCase() === b.staticInput.toLowerCase()
   );
 }


### PR DESCRIPTION
This code doesn't change the logic, it only adds more logs and refactors the code a bit.

1. Added more logs
2. Removed excessive exports
3. Got rid of excessive ComposableCoW contract instances
4. Added "Conditional order params are equal but not the same" log

The last point is my suspect. I assume that comparation here is not valid, we should not use shallow comparison for the objects.