### PR TITLE
fix: fix crash with error in log

### DIFF
--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -288,8 +288,6 @@ function replacer(_key: any, value: any) {
   }
 }
 
-const loadOwnerOrdersLogger = getLogger("loadOwnerOrders");
-
 async function loadOwnerOrders(
   storage: DBService,
   network: string
@@ -313,7 +311,8 @@ async function loadOwnerOrders(
     version
   );
 
-  loadOwnerOrdersLogger.info(
+  const log = getLogger("loadOwnerOrders");
+  log.info(
     `Data size: ${str?.length}`,
     `Owners: ${ordersPerOwner.size}`,
     `Total orders: ${getOrdersCountFromOrdersPerOwner(ordersPerOwner)}`,


### PR DESCRIPTION
# Description
We have a crash in watch-tower staging env after https://github.com/cowprotocol/watch-tower/pull/164

see 
https://aws-es.cow.fi/_dashboards/app/data-explorer/discover/#/view/70561750-b0ee-11ef-8199-15daae69bf9c?_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'5ed837d0-4a67-11ef-8b11-a98c7c46873d',key:kubernetes.pod_labels.app,negate:!f,params:(query:watch-tower),type:phrase),query:(match_phrase:(kubernetes.pod_labels.app:watch-tower)))),query:(language:kuery,query:''))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-15h,to:now))&_a=(discover:(columns:!(log,log_level),isDirty:!f,savedSearch:'70561750-b0ee-11ef-8199-15daae69bf9c',sort:!()),metadata:(indexPattern:'5ed837d0-4a67-11ef-8b11-a98c7c46873d',view:discover))


<img width="1439" alt="image" src="https://github.com/user-attachments/assets/4b4f5ebc-4b40-4cec-803c-d52094dbd114">
