### PR TITLE
fix: fix circular dependency issue

### DIFF
--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -8,7 +8,8 @@ import {
   PollResult,
 } from "@cowprotocol/cow-sdk";
 import { DBService } from "../services";
-import { getLogger, metrics } from "../utils";
+import * as metrics from "../utils/metrics";
+import { getLogger } from "../utils/logging";
 
 // Standardise the storage key
 const LAST_NOTIFIED_ERROR_STORAGE_KEY = "LAST_NOTIFIED_ERROR";


### PR DESCRIPTION
# Description

1. We import `import { getLogger } from "../utils";` in `types/model.ts`
2. `export * from "./model";`  is in `types/index.ts`
3. `types/index.ts` is used in `utils/misc.ts`
4. `utils/misc.ts` is exported from `"../utils"`