### PR TITLE
feat: improve log debuggability

### DIFF
--- a/src/commands/dumpDb.ts
+++ b/src/commands/dumpDb.ts
@@ -7,7 +7,7 @@ import { getLogger } from "../utils";
  * @param options A dict, but essentially just the chainId
  */
 export async function dumpDb(options: DumpDbOptions) {
-  const log = getLogger("commands:dumpDb");
+  const log = getLogger({ name: "commands:dumpDb" });
   const { chainId, databasePath } = options;
 
   Registry.dump(DBService.getInstance(databasePath), chainId.toString())

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -7,7 +7,7 @@ import { DBService, ApiService, ChainContext } from "../services";
  * @param options Specified by the CLI / environment for running the watch-tower
  */
 export async function run(options: RunOptions) {
-  const log = getLogger("commands:run");
+  const log = getLogger({ name: "commands:run" });
   const { oneShot, disableApi, apiPort, databasePath, networks } = options;
 
   // Open the database
@@ -66,7 +66,7 @@ export async function run(options: RunOptions) {
  * @param exitCode Exit code to return to the shell
  */
 async function stop(exitCode?: number) {
-  const log = getLogger("commands:stop");
+  const log = getLogger({ name: "commands:stop" });
   const stopServices = [
     ApiService.getInstance().stop(),
     DBService.getInstance().close(),

--- a/src/domain/polling/poll.ts
+++ b/src/domain/polling/poll.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_CONDITIONAL_ORDER_REGISTRY,
   PollParams,
   PollResult,
+  SupportedChainId,
 } from "@cowprotocol/cow-sdk";
 import { getLogger } from "../../utils/logging";
 
@@ -18,9 +19,19 @@ export async function pollConditionalOrder(
   conditionalOrderId: string,
   pollParams: PollParams,
   conditionalOrderParams: ConditionalOrderParams,
-  orderRef: string
+  chainId: SupportedChainId,
+  blockNumber: number,
+  ownerNumber: number,
+  orderNumber: number
 ): Promise<PollResult | undefined> {
-  const log = getLogger("pollConditionalOrder:pollConditionalOrder", orderRef);
+  const log = getLogger({
+    name: "pollConditionalOrder",
+    chainId,
+    blockNumber,
+    ownerNumber,
+    orderNumber,
+  });
+
   const order = ordersFactory.fromParams(conditionalOrderParams);
 
   if (!order) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -50,7 +50,7 @@ export class ApiService {
   async start(): Promise<Server> {
     return await new Promise((resolve, reject) => {
       try {
-        const log = getLogger("api:start");
+        const log = getLogger({ name: "api:start" });
         if (this.server?.listening) {
           throw new Error("Server is already running");
         }
@@ -74,7 +74,7 @@ export class ApiService {
           throw new Error("Server is not running");
         }
 
-        const log = getLogger("api:stop");
+        const log = getLogger({ name: "api:stop" });
         log.info("Stopping Rest API server...");
 
         this.server.once("close", resolve);

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -28,13 +28,13 @@ export class DBService {
   }
 
   public async open() {
-    const log = getLogger("dbService:open");
+    const log = getLogger({ name: "dbService:open" });
     log.info("Opening database...");
     await this.db.open();
   }
 
   public async close() {
-    const log = getLogger("dbService:close");
+    const log = getLogger({ name: "dbService:close" });
     log.info("Closing database...");
     await this.db.close();
   }

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -110,7 +110,7 @@ export class Registry {
   network: string;
   lastNotifiedError: Date | null;
   lastProcessedBlock: RegistryBlock | null;
-  readonly logger = getLogger("Registry");
+  readonly logger = getLogger({ name: "Registry" });
   /**
    * Instantiates a registry.
    * @param ownerOrders What map to populate the registry with
@@ -200,6 +200,10 @@ export class Registry {
     return getOrdersCountFromOrdersPerOwner(this.ownerOrders);
   }
 
+  get numOwners(): number {
+    return this.ownerOrders.size;
+  }
+
   /**
    * Write the registry to storage.
    */
@@ -250,10 +254,9 @@ export class Registry {
     await batch.write();
 
     this.logger.debug(
-      `write:${this.version}:${this.network}:${
-        this.lastProcessedBlock?.number
-      }:${this.lastNotifiedError || ""}`,
-      "batch written 📝"
+      `${this.network}@${this.lastProcessedBlock?.number}:v${this.version}${
+        this.lastNotifiedError ? ":lastError_" + this.lastNotifiedError : ""
+      } DB persisted`
     );
   }
 
@@ -293,7 +296,7 @@ async function loadOwnerOrders(
   storage: DBService,
   network: string
 ): Promise<OrdersPerOwner> {
-  const loadOwnerOrdersLogger = getLogger("loadOwnerOrders");
+  const loadOwnerOrdersLogger = getLogger({ name: "loadOwnerOrders" });
   // Get the owner orders
   const db = storage.getDB();
   const str = await db.get(

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -59,7 +59,7 @@ function _getSlack(options: ContextOptions): Slack | undefined {
 }
 
 export async function handleExecutionError(e: any) {
-  const log = getLogger("context:handleExecutionError");
+  const log = getLogger({ name: "context:handleExecutionError" });
   try {
     const errorMessage = e?.message || "Unknown error";
     const notified = sendSlack(
@@ -80,7 +80,7 @@ export async function handleExecutionError(e: any) {
 }
 
 export function sendSlack(message: string): boolean {
-  const log = getLogger("context:sendSlack");
+  const log = getLogger({ name: "context:sendSlack" });
   if (!executionContext) {
     log.warn("Slack not initialized, ignoring message", message);
     return false;

--- a/src/utils/utils.spec.ts
+++ b/src/utils/utils.spec.ts
@@ -65,6 +65,9 @@ describe("handle on-chain custom errors", () => {
       CUSTOM_ERROR_ABI_MAP[CustomErrorSelectors.SINGLE_ORDER_NOT_AUTHED]
     ),
     metricLabels: ["chain_id", "handler", "owner", "id"],
+    blockNumber: 123456,
+    ownerNumber: 2,
+    orderNumber: 3,
   };
 
   it("should pass a known selector correctly", () => {


### PR DESCRIPTION
# Description
Improve logs to make them easier to debug issues. 

Logs were not great, and won't be great after this PR. The goal of this PR is to improve some aspects of the logs to make it easier to debug.

It is very useful to be able to filter by block number, or by owner, or order number. Before this PR there was some context, but this context was missing in some parts, what made things like "filtering logs per block" to not work. Now all logs include the chain id and the block number.

See example:
<img width="1699" alt="Screenshot at Dec 05 22-17-10" src="https://github.com/user-attachments/assets/642e92e7-0577-42ca-bca1-721338dc5e82">

Additionally, it simplifies some logger names and function names, and improve some messages so they are easier to read. 

It also shows information about the number of owners and orders and how many left to process. 

The PR also makes the logger utility to receive this context raw params, so we can make the logger prefix constant. Before we used to concatenate the fields, and we were not systematic with the order.


Anyways, as mentioned, logging is still not great specially in terms of code cleanness, but at least now the logs are a bit easier to debug.