### PR TITLE
feat: add sync status and time from last indexed block

### DIFF
--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -41,7 +41,7 @@ export function measureTime<T, U>({
 
 export const syncStatus = new client.Gauge({
   name: "watch_tower_sync_status",
-  help: "Sync status of watch rower. 1 if in sync, 0 otherwise",
+  help: "Sync status. 1 if in sync, 0 otherwise",
   labelNames: ["chain_id"],
 });
 

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -39,9 +39,21 @@ export function measureTime<T, U>({
   return result;
 }
 
+export const syncStatus = new client.Gauge({
+  name: "watch_tower_sync_status",
+  help: "Sync status of watch rower. 1 if in sync, 0 otherwise",
+  labelNames: ["chain_id"],
+});
+
+export const blockTimestamp = new client.Gauge({
+  name: "watch_tower_block_timestamp",
+  help: "Block timestamp of the last processed block",
+  labelNames: ["chain_id"],
+});
+
 export const blockHeight = new client.Gauge({
   name: "watch_tower_block_height",
-  help: "Block height of the block watcher",
+  help: "Block height of the last processed block",
   labelNames: ["chain_id"],
 });
 


### PR DESCRIPTION
# Description
One of the things is super hard to monitor in Watch Tower is the sync status. 

## The problem
Syncing from the origin of times (deployment of composable cow), can take a while.  Currently, Its super hard to see which instances of watch-tower are in sync.

Further more, if there's a crash, or you restart a pod, it will enter in sync mode (to catch up). There could be issues of not catching up fast enough. Its very hard to see that your watch-tower is lagging behind.

# Additions in this PR
## Sync status metric
Now, there's a new prometheus metric for the SYNC status.

```
# HELP watch_tower_sync_status Sync status of watch rower. 1 if in sync, 0 otherwise
# TYPE watch_tower_sync_status gauge
watch_tower_sync_status{chain_id="1"} 0
```

## Last block
Once we know we are SYNCING, its hard to tell how far we are from the tip of the blockchain. 

We have some metric to know the last indexed block, but this is hard to use to get a quick idea if we are catching up. With the block you see a growing number, that then you need to check how far from the tip is in a block explorer.

This PR creates a new metric with the timestamp of the latest block. This way, we can present the distance to NOW, to show how far we are from a full sync. Also, as we see the updates in the dashboard real time, we can see the rate in which this relative time decreases.

```
# HELP watch_tower_block_timestamp Block timestamp of the last processed block
# TYPE watch_tower_block_timestamp gauge
watch_tower_block_timestamp{chain_id="1"} 1722003767
```