### PR TITLE
feat: add metric for the latest block from the chain (tip)

### DIFF
--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -189,7 +189,11 @@ export class ChainContext {
     let fromBlock = lastProcessedBlock
       ? lastProcessedBlock.number + 1
       : this.deploymentBlock;
+
     let currentBlock = await provider.getBlock("latest");
+    metrics.blockHeightLatest
+      .labels(chainId.toString())
+      .set(currentBlock.number);
 
     let printSyncInfo = true; // Print sync info only once
     let toBlock: "latest" | number = 0;
@@ -199,6 +203,9 @@ export class ChainContext {
         if (typeof toBlock === "number" && toBlock > currentBlock.number) {
           // refresh the current block
           currentBlock = await provider.getBlock("latest");
+          metrics.blockHeightLatest
+            .labels(chainId.toString())
+            .set(currentBlock.number);
           toBlock =
             toBlock > currentBlock.number ? currentBlock.number : toBlock;
 
@@ -283,6 +290,9 @@ export class ChainContext {
       // It may have taken some time to process the blocks, so refresh the current block number
       // and check if we are in sync
       currentBlock = await provider.getBlock("latest");
+      metrics.blockHeightLatest
+        .labels(chainId.toString())
+        .set(currentBlock.number);
 
       // If we are in sync, let it be known
       const lastProcessedBlockNumber = lastProcessedBlock?.number || 0;

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -57,6 +57,12 @@ export const blockHeight = new client.Gauge({
   labelNames: ["chain_id"],
 });
 
+export const blockHeightLatest = new client.Gauge({
+  name: "watch_tower_block_height_latest",
+  help: "Block height of the last block (tip of the chain)",
+  labelNames: ["chain_id"],
+});
+
 export const reorgDepth = new client.Gauge({
   name: "watch_tower_latest_reorg_depth",
   help: "Depth of the most recent reorg",


### PR DESCRIPTION
# Description

Follow up on https://github.com/cowprotocol/watch-tower/pull/171

This PR adds the latest mined block (tip of the chain).

It allow us to build a burn-down chart on how far we are from the chain (as we consume blocks).

This is useful to see that indeed the slope is downwards.
Otherwise, we won't arrive to the tip of the chain! 😄 

# Changes
Include a new metric

```

# HELP watch_tower_block_height_latest Block height of the last block (tip of the chain)
# TYPE watch_tower_block_height_latest gauge
watch_tower_block_height_latest{chain_id="1"} 21351273

```