### PR TITLE
fix: fix missing update on the latest block

### DIFF
--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -335,6 +335,8 @@ export class ChainContext {
     log.debug(`Watchdog timeout: ${watchdogTimeout} seconds`);
     let lastBlockReceived = lastProcessedBlock;
     provider.on("block", async (blockNumber: number) => {
+      metrics.blockHeight.labels(chainId.toString()).set(blockNumber);
+
       try {
         log = getLogger({
           name: loggerName,


### PR DESCRIPTION
# Description

Follow up on an error from #172 

Basically, I forgot to update the latest block after the warm up (when we are subscribing to new blocks)

I noticed, because the chart looks funny!

<img width="1426" alt="image" src="https://github.com/user-attachments/assets/737bbdf0-c155-4603-91d7-94b9aaae3f2d">

This PR should address the issue.