### PR TITLE
feat: expose config in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ The server exposes automatically:
 
 - An API, with:
   - Version info: [http://localhost:8080/api/version](http://localhost:8080/api/version)
+  - Config: [http://localhost:8080/api/config](http://localhost:8080/api/config)
   - Dump Database: `http://localhost:8080/api/dump/:chainId` e.g. [http://localhost:8080/api/dump/1](http://localhost:8080/api/dump/1)
 - Prometheus Metrics: [http://localhost:8080/metrics](http://localhost:8080/metrics)
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -14,9 +14,10 @@ export async function run(options: RunOptions) {
   const storage = DBService.getInstance(databasePath);
 
   // Start the API server if it's not disabled
+  let api: ApiService | undefined;
   if (!disableApi) {
     log.info("Starting Rest API server...");
-    const api = ApiService.getInstance(apiPort);
+    api = ApiService.getInstance(apiPort);
     await api.start();
   }
 
@@ -45,6 +46,9 @@ export async function run(options: RunOptions) {
         );
       })
     );
+
+    // Set the chain contexts on the API server
+    api?.setChainContexts(chainContexts);
 
     // Run the block watcher after warm up for each chain
     const runPromises = chainContexts.map(async (context) => {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -12,6 +12,8 @@ export class ApiService {
   protected app: Express;
   protected server: Server | null = null;
 
+  protected chainContexts: ChainContext[] = [];
+
   private static _instance: ApiService | undefined;
 
   protected constructor(port?: number) {
@@ -36,6 +38,32 @@ export class ApiService {
     this.app.get("/health", async (_req: Request, res: Response) => {
       const health = ChainContext.health;
       res.status(health.overallHealth ? 200 : 503).send(health);
+    });
+    this.app.use("/config", (_req: Request, res: Response) => {
+      res.setHeader("Content-Type", "application/json");
+      res.status(200).send(
+        this.chainContexts.map(
+          ({
+            chainId,
+            contract,
+            deploymentBlock,
+            dryRun,
+            filterPolicy,
+            pageSize,
+            processEveryNumBlocks,
+            addresses,
+          }) => ({
+            chainId,
+            contract: contract.address,
+            deploymentBlock,
+            dryRun,
+            filterPolicy,
+            pageSize,
+            processEveryNumBlocks,
+            addresses,
+          })
+        )
+      );
     });
     this.app.use("/api", router);
   }
@@ -83,6 +111,14 @@ export class ApiService {
         reject(err);
       }
     });
+  }
+
+  setChainContexts(chainContexts: ChainContext[]) {
+    this.chainContexts = chainContexts;
+  }
+
+  getChainContexts() {
+    return this.chainContexts;
   }
 }
 


### PR DESCRIPTION
# Description
Include a new endpoint that exposes the main configuration


## Context
Watch tower exposes the version being used:
<img width="1043" alt="image" src="https://github.com/user-attachments/assets/3c8cbd26-8224-419c-b6d3-d93ebc258a8b" />


However, its not easy to tell which filtering policies are being applied. 
For this reason, I included a new endpoint that exposes the most relevant config info.

<img width="858" alt="image" src="https://github.com/user-attachments/assets/36b2f686-2924-4f76-b295-d2f41cba5e52" />

## Test
Run locally with your custom config. Check http://localhost:8080/config