### PR TITLE
chore: update `cow-sdk` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cowprotocol/watch-tower",
   "license": "GPL-3.0-or-later",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "description": "A standalone watch tower, keeping an eye on Composable Cows  👀🐮",
   "author": {
     "name": "Cow Protocol"
@@ -46,7 +46,7 @@
   "dependencies": {
     "@commander-js/extra-typings": "^11.0.0",
     "@cowprotocol/contracts": "^1.4.0",
-    "@cowprotocol/cow-sdk": "6.0.0-RC.53",
+    "@cowprotocol/cow-sdk": "6.0.0-RC.59",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "chalk": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -497,10 +497,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.8.0.tgz#daffbd9846231c11a74b15a186bb754627e420b0"
   integrity sha512-rMEHo1UBB6k4kRoWejHZNGggg6IBVt7vAd8x0FhEvjxhbq3zlAex61f9HpAcDExJNuvfwwDjsOc/7UGztCzhSw==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.53":
-  version "6.0.0-RC.53"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.53.tgz#b97055f4b3fce7139b477259b11f1443cd3425da"
-  integrity sha512-jZmWJOgYspXm1n1lympNbpxwP4u2pAIA23Lpzw5xVmlrScxcKlb3E9nkTsRqXuDaPFql+wMkbxJIpkXUBIjWuA==
+"@cowprotocol/cow-sdk@6.0.0-RC.59":
+  version "6.0.0-RC.59"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.59.tgz#6981c912fff982b30b3a015df4bed3127dd59186"
+  integrity sha512-VqqtyxzfAw4jzltNXz0/1fU1rgHBRi3XQAIXcaisdZRipsVeM8G1Mt3T+TvXvUGT4lB3Dn9nU3EYyXXlC1aXXA==
   dependencies:
     "@cowprotocol/app-data" "^3.1.0"
     "@cowprotocol/contracts" "^1.8.0"


### PR DESCRIPTION
# Description
- update `cow-sdk` to the latest release `v6.0.0-RC.59`
- bump version to `v2.11.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated package version to 2.11.1.
  - Upgraded dependency for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->