### PR TITLE
feat(new-networks): add lens and bnb support

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@commander-js/extra-typings": "^11.0.0",
     "@cowprotocol/contracts": "^1.4.0",
-    "@cowprotocol/cow-sdk": "6.1.0p-lens-bsc.4",
+    "@cowprotocol/cow-sdk": "6.2.0-RC.0",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@commander-js/extra-typings": "^11.0.0",
     "@cowprotocol/contracts": "^1.4.0",
-    "@cowprotocol/cow-sdk": "6.0.0-RC.59",
+    "@cowprotocol/cow-sdk": "6.1.0p-lens-bsc.4",
     "ajv": "^8.12.0",
     "ajv-formats": "^2.1.1",
     "chalk": "^4.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -497,10 +497,10 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.8.0.tgz#daffbd9846231c11a74b15a186bb754627e420b0"
   integrity sha512-rMEHo1UBB6k4kRoWejHZNGggg6IBVt7vAd8x0FhEvjxhbq3zlAex61f9HpAcDExJNuvfwwDjsOc/7UGztCzhSw==
 
-"@cowprotocol/cow-sdk@6.0.1-lens-bsc.4":
-  version "6.1.0-lens-bsc.4"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.1.0-lens-bsc.4.tgz#f579d29e9d7ddee7fec9a6279f60ac3d217633af"
-  integrity sha512-4PykRudyDFVOkwg+NuPpt9WAoB82epOJnyUBkj01x4Hm0osjnKUcAngAXx5peBH5Me9j+x2FoGRaB2WV0MMVKA==
+"@cowprotocol/cow-sdk@6.2.0-RC.0":
+  version "6.2.0-RC.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.2.0-RC.0.tgz#120af7c184ba8ce7b1cfc92e5ebdf83f84237e83"
+  integrity sha512-Dmg8BYehkeW3QjeovBvW56C6tS7z6S+WOU/W4NUt67gedjrSi5Rd8AxVdZzZ3wFR07ClAYyeQ88UujPbxC+buQ==
   dependencies:
     "@cowprotocol/app-data" "^3.3.0"
     "@cowprotocol/contracts" "^1.8.0"
@@ -511,7 +511,7 @@
     deepmerge "^4.3.1"
     exponential-backoff "^3.1.2"
     graphql "^16.11.0"
-    graphql-request "^4.3.0"
+    graphql-request "^6.1.0"
     limiter "^3.0.0"
 
 "@cspotcode/source-map-support@^0.8.0":
@@ -3271,11 +3271,6 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-extract-files@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
-  integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
-
 extsprintf@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
@@ -3430,15 +3425,6 @@ form-data@^2.5.0:
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.6"
-    mime-types "^2.1.12"
-
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
 form-data@^4.0.0:
@@ -3640,15 +3626,6 @@ graphemer@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
-
-graphql-request@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.3.0.tgz#b934e08fcae764aa2cdc697d3c821f046cb5dbf2"
-  integrity sha512-2v6hQViJvSsifK606AliqiNiijb1uwWp6Re7o0RTyH+uRTv/u7Uqm2g4Fjq/LgZIzARB38RZEvVBFOQOVdlBow==
-  dependencies:
-    cross-fetch "^3.1.5"
-    extract-files "^9.0.0"
-    form-data "^3.0.0"
 
 graphql-request@^6.1.0:
   version "6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -476,10 +476,10 @@
   dependencies:
     chalk "^4.1.0"
 
-"@cowprotocol/app-data@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-3.1.0.tgz#2ba5ec7d958b2510f17b08c7e18e05157032c4da"
-  integrity sha512-hdIWp6fGz/vx3gdoJgwd8Dx8rYAblpZEBiXss5mNzgF/LBb21VVhF075sDl9oxyesKuJayKjgiAgaFiZYVgblA==
+"@cowprotocol/app-data@^3.3.0":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/app-data/-/app-data-3.3.0.tgz#644e7473a00eb5e6694a34d34b4359c6d7ef1060"
+  integrity sha512-3lfknouwg+j/xSyL5u5FI8rAlGPkzi+QsmXQvPS0O0ETaikx9v9pt5t3pZOv6jtsAmafFBFPtAUp/cdPrDSUaA==
   dependencies:
     ajv "^8.11.0"
     cross-fetch "^3.1.5"
@@ -497,19 +497,18 @@
   resolved "https://registry.yarnpkg.com/@cowprotocol/contracts/-/contracts-1.8.0.tgz#daffbd9846231c11a74b15a186bb754627e420b0"
   integrity sha512-rMEHo1UBB6k4kRoWejHZNGggg6IBVt7vAd8x0FhEvjxhbq3zlAex61f9HpAcDExJNuvfwwDjsOc/7UGztCzhSw==
 
-"@cowprotocol/cow-sdk@6.0.0-RC.59":
-  version "6.0.0-RC.59"
-  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.0.0-RC.59.tgz#6981c912fff982b30b3a015df4bed3127dd59186"
-  integrity sha512-VqqtyxzfAw4jzltNXz0/1fU1rgHBRi3XQAIXcaisdZRipsVeM8G1Mt3T+TvXvUGT4lB3Dn9nU3EYyXXlC1aXXA==
+"@cowprotocol/cow-sdk@6.0.1-lens-bsc.4":
+  version "6.1.0-lens-bsc.4"
+  resolved "https://registry.yarnpkg.com/@cowprotocol/cow-sdk/-/cow-sdk-6.1.0-lens-bsc.4.tgz#f579d29e9d7ddee7fec9a6279f60ac3d217633af"
+  integrity sha512-4PykRudyDFVOkwg+NuPpt9WAoB82epOJnyUBkj01x4Hm0osjnKUcAngAXx5peBH5Me9j+x2FoGRaB2WV0MMVKA==
   dependencies:
-    "@cowprotocol/app-data" "^3.1.0"
+    "@cowprotocol/app-data" "^3.3.0"
     "@cowprotocol/contracts" "^1.8.0"
     "@ethersproject/abstract-signer" "^5.8.0"
     "@openzeppelin/merkle-tree" "^1.0.8"
     "@weiroll/weiroll.js" "^0.3.0"
     cross-fetch "^3.2.0"
     deepmerge "^4.3.1"
-    ethers "^5.8.0"
     exponential-backoff "^3.1.2"
     graphql "^16.11.0"
     graphql-request "^4.3.0"
@@ -3112,7 +3111,7 @@ ethereum-cryptography@^3.0.0:
     "@scure/bip32" "1.7.0"
     "@scure/bip39" "1.6.0"
 
-ethers@5.8.0, ethers@^5.3.1, ethers@^5.8.0:
+ethers@5.8.0, ethers@^5.3.1:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/ethers/-/ethers-5.8.0.tgz#97858dc4d4c74afce83ea7562fe9493cedb4d377"
   integrity sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==


### PR DESCRIPTION
# Description

Add Lens and BNB support for the watch tower

# Changes

- [ ] Bumped cow-sdk version to https://github.com/cowprotocol/cow-sdk/releases/tag/v6.2.0-lens-bsc.0

## How to test

1. Setup lens config:
```
{
  "networks": [
    {
      "name": "lens",
      "rpc": "https://rpc.lens.xyz",
      "deploymentBlock": 3516559,
      "watchdogTimeout": 300,
      "pageSize": 50000,
      "filterPolicy": {},
        "owners": {},
        "transactions": {}
      },
      "processEveryNumBlocks": 5
    }
  ]
}
```
2. Start service with `yarn cli run`
* Should start without issues

3. Connect https://swap-dev-git-feat-lens-bsc-cowswap-dev.vercel.app/ to a Lens Safe
4. Fund it 
5. Go to TWAP, place a TWAP order
* Order should be placed
* First order part should be created

⚠️ Orderbook MUST be deployed to prod ⚠️ 