### PR TITLE
feat: log memory usage and shutdown

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -5,7 +5,7 @@ import { DBService, ApiService, ChainContext } from "../services";
 // How often to log the process memory usage. This leaves a memory trail in the
 // logs so a restart can be correlated with memory pressure (e.g. OOM) even when
 // only the application logs are available.
-const MEMORY_LOG_FREQUENCY_SECS = 60;
+const MEMORY_LOG_INTERVAL_MS = 60_000;
 
 /**
  * Run the watch-tower 👀🐮
@@ -31,7 +31,7 @@ export async function run(options: RunOptions) {
   log.info(`Memory usage: ${formatMemoryUsage(process.memoryUsage())}`);
   const memoryLogInterval = setInterval(() => {
     log.info(`Memory usage: ${formatMemoryUsage(process.memoryUsage())}`);
-  }, MEMORY_LOG_FREQUENCY_SECS * 1000);
+  }, MEMORY_LOG_INTERVAL);
   memoryLogInterval.unref();
 
   process.on("unhandledRejection", async (error) => {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -31,7 +31,7 @@ export async function run(options: RunOptions) {
   log.info(`Memory usage: ${formatMemoryUsage(process.memoryUsage())}`);
   const memoryLogInterval = setInterval(() => {
     log.info(`Memory usage: ${formatMemoryUsage(process.memoryUsage())}`);
-  }, MEMORY_LOG_INTERVAL);
+  }, MEMORY_LOG_INTERVAL_MS);
   memoryLogInterval.unref();
 
   process.on("unhandledRejection", async (error) => {

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,5 +1,5 @@
 import { RunOptions } from "../types";
-import { formatMemoryUsage, getLogger } from "../utils";
+import { getLogger } from "../utils";
 import { DBService, ApiService, ChainContext } from "../services";
 
 // How often to log the process memory usage. This leaves a memory trail in the
@@ -108,4 +108,11 @@ async function stop(exitCode?: number, memoryLogInterval?: NodeJS.Timeout) {
   });
   log.info("Exiting watchtower...");
   process.exit(exitCode || 0);
+}
+
+function formatMemoryUsage(usage: NodeJS.MemoryUsage): string {
+  const toMB = (bytes: number) => Math.round(bytes / 1024 / 1024);
+  return `rss=${toMB(usage.rss)}MB heapUsed=${toMB(
+    usage.heapUsed
+  )}MB heapTotal=${toMB(usage.heapTotal)}MB external=${toMB(usage.external)}MB`;
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,11 @@
 import { RunOptions } from "../types";
-import { getLogger } from "../utils";
+import { formatMemoryUsage, getLogger } from "../utils";
 import { DBService, ApiService, ChainContext } from "../services";
+
+// How often to log the process memory usage. This leaves a memory trail in the
+// logs so a restart can be correlated with memory pressure (e.g. OOM) even when
+// only the application logs are available.
+const MEMORY_LOG_FREQUENCY_SECS = 60;
 
 /**
  * Run the watch-tower 👀🐮
@@ -21,15 +26,30 @@ export async function run(options: RunOptions) {
     await api.start();
   }
 
+  // Periodically log memory usage. `unref()` ensures this timer never keeps the
+  // process alive on its own.
+  log.info(`Memory usage: ${formatMemoryUsage(process.memoryUsage())}`);
+  const memoryLogInterval = setInterval(() => {
+    log.info(`Memory usage: ${formatMemoryUsage(process.memoryUsage())}`);
+  }, MEMORY_LOG_FREQUENCY_SECS * 1000);
+  memoryLogInterval.unref();
+
   process.on("unhandledRejection", async (error) => {
     log.error("Unhandled promise rejection", error);
-    await stop(1);
+    await stop(1, memoryLogInterval);
   });
 
-  process.on("SIGINT", async function () {
-    log.info("Caught interrupt signal.");
-    await stop();
-  });
+  // Handle both termination signals so that shutdowns are graceful and, more
+  // importantly, leave a log trail. Kubernetes sends SIGTERM to restart a pod
+  // (rollout, eviction, failing liveness probe); without a handler Node exits
+  // instantly and silently, making a routine k8s restart indistinguishable in
+  // the logs from an uncatchable SIGKILL / OOM kill.
+  const handleSignal = (signal: NodeJS.Signals) => async () => {
+    log.info(`Caught ${signal} signal. Shutting down...`);
+    await stop(0, memoryLogInterval);
+  };
+  process.on("SIGINT", handleSignal("SIGINT"));
+  process.on("SIGTERM", handleSignal("SIGTERM"));
 
   let exitCode = 0;
   try {
@@ -61,16 +81,20 @@ export async function run(options: RunOptions) {
     log.error("Unexpected error thrown when running watchtower", error);
     exitCode = 1;
   } finally {
-    await stop(exitCode);
+    await stop(exitCode, memoryLogInterval);
   }
 }
 
 /**
  * Run actions required when stopping the watch-tower from run mode
  * @param exitCode Exit code to return to the shell
+ * @param memoryLogInterval Memory logging timer to clear before exiting
  */
-async function stop(exitCode?: number) {
+async function stop(exitCode?: number, memoryLogInterval?: NodeJS.Timeout) {
   const log = getLogger({ name: "commands:stop" });
+  if (memoryLogInterval) {
+    clearInterval(memoryLogInterval);
+  }
   const stopServices = [
     ApiService.getInstance().stop(),
     DBService.getInstance().close(),


### PR DESCRIPTION
1. Add a `SIGTERM` handler (mirroring the SIGINT one). Next time it will log a clean shutdown on any k8s-initiated restart, so silence will then unambiguously mean SIGKILL/OOM. Right now the two cases are indistinguishable.
2. Periodically log memory usage to see when OOM happens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Monitoring**
  * Added periodic memory usage logging (RSS, heap, and external), reported on a timed cadence with values formatted in megabytes.

* **Bug Fixes**
  * Improved shutdown handling so the memory monitoring stops cleanly on normal completion and on error conditions.
  * Added graceful shutdown support for both SIGINT and SIGTERM, ensuring termination triggers exit after stopping monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->