### PR TITLE
fix: improve reorg detection, only when they actually happen

### DIFF
--- a/src/services/chain.spec.ts
+++ b/src/services/chain.spec.ts
@@ -1,5 +1,5 @@
 import { providers } from "ethers";
-import { isReorg } from "./chain";
+import { getEventPollingRange, isReorg } from "./chain";
 
 const block = (
   number: number,
@@ -23,6 +23,12 @@ describe("isReorg", () => {
   it("detects a consecutive block with a different parent", async () => {
     await expect(
       isReorg(provider, block(10, "old"), block(11, "new", "fork"))
+    ).resolves.toBe(true);
+  });
+
+  it("detects a lower replacement head", async () => {
+    await expect(
+      isReorg(provider, block(10, "old"), block(8, "fork"))
     ).resolves.toBe(true);
   });
 
@@ -50,4 +56,19 @@ describe("isReorg", () => {
       isReorg(provider, block(10, "old"), block(13, "new"))
     ).rejects.toThrow("RPC failed");
   });
+});
+
+describe("getEventPollingRange", () => {
+  it.each([
+    [10, 11, [11, 11]],
+    [10, 13, [11, 13]],
+    [10, 8, [8, 8]],
+  ])(
+    "returns the event range after block %i for incoming block %i",
+    (previousBlockNumber, blockNumber, expected) => {
+      expect(getEventPollingRange(previousBlockNumber, blockNumber)).toEqual(
+        expected
+      );
+    }
+  );
 });

--- a/src/services/chain.spec.ts
+++ b/src/services/chain.spec.ts
@@ -27,9 +27,20 @@ describe("isReorg", () => {
   });
 
   it("detects a lower replacement head", async () => {
+    provider.getBlock = jest.fn().mockResolvedValue(block(10, "fork"));
+
     await expect(
       isReorg(provider, block(10, "old"), block(8, "fork"))
     ).resolves.toBe(true);
+    expect(provider.getBlock).toHaveBeenCalledWith(10);
+  });
+
+  it("accepts a delayed lower block when the previous block remains canonical", async () => {
+    provider.getBlock = jest.fn().mockResolvedValue(block(10, "old"));
+
+    await expect(
+      isReorg(provider, block(10, "old"), block(8, "canonical"))
+    ).resolves.toBe(false);
   });
 
   it("accepts a block gap when the previous block remains canonical", async () => {

--- a/src/services/chain.spec.ts
+++ b/src/services/chain.spec.ts
@@ -1,0 +1,53 @@
+import { providers } from "ethers";
+import { isReorg } from "./chain";
+
+const block = (
+  number: number,
+  hash: string,
+  parentHash = ""
+): providers.Block => ({ number, hash, parentHash } as providers.Block);
+
+describe("isReorg", () => {
+  const provider = {
+    getBlock: jest.fn(),
+  } as unknown as providers.Provider;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it("accepts a consecutive block with the expected parent", async () => {
+    await expect(
+      isReorg(provider, block(10, "old"), block(11, "new", "old"))
+    ).resolves.toBe(false);
+  });
+
+  it("detects a consecutive block with a different parent", async () => {
+    await expect(
+      isReorg(provider, block(10, "old"), block(11, "new", "fork"))
+    ).resolves.toBe(true);
+  });
+
+  it("accepts a block gap when the previous block remains canonical", async () => {
+    provider.getBlock = jest.fn().mockResolvedValue(block(10, "old"));
+
+    await expect(
+      isReorg(provider, block(10, "old"), block(13, "new"))
+    ).resolves.toBe(false);
+    expect(provider.getBlock).toHaveBeenCalledWith(10);
+  });
+
+  it("detects a block gap when the previous block is no longer canonical", async () => {
+    provider.getBlock = jest.fn().mockResolvedValue(block(10, "fork"));
+
+    await expect(
+      isReorg(provider, block(10, "old"), block(13, "new"))
+    ).resolves.toBe(true);
+  });
+
+  it("propagates gap verification errors to the subscription handler", async () => {
+    provider.getBlock = jest.fn().mockRejectedValue(new Error("RPC failed"));
+
+    await expect(
+      isReorg(provider, block(10, "old"), block(13, "new"))
+    ).rejects.toThrow("RPC failed");
+  });
+});

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -348,56 +348,56 @@ export class ChainContext {
     log.info(`👀 Start block watcher`);
     log.debug(`Watchdog timeout: ${watchdogTimeout} seconds`);
     let lastBlockReceived = lastProcessedBlock;
-    provider.on("block", async (blockNumber: number) => {
+    // Chain callbacks onto a resolved promise so blocks are processed sequentially.
+    let processing = Promise.resolve();
+    provider.on("block", (blockNumber: number) => {
       metrics.blockHeightLatest.labels(chainId.toString()).set(blockNumber);
 
-      try {
-        log = getLogger({
-          name: loggerName,
-          chainId,
-          blockNumber,
-        });
-        log.debug("New block received");
+      processing = processing.then(async () => {
+        try {
+          log = getLogger({
+            name: loggerName,
+            chainId,
+            blockNumber,
+          });
+          log.debug("New block received");
 
-        const block = await provider.getBlock(blockNumber);
+          const block = await provider.getBlock(blockNumber);
+          if (block.number < lastBlockReceived.number) {
+            log.debug(`Ignoring stale block ${block.number}`);
+            return;
+          }
 
-        // Set the block time metric
-        const _blockTime = block.timestamp - lastBlockReceived.timestamp;
-        metrics.blockProducingRate.labels(chainId.toString()).set(_blockTime);
+          // Set the block time metric
+          const _blockTime = block.timestamp - lastBlockReceived.timestamp;
+          metrics.blockProducingRate.labels(chainId.toString()).set(_blockTime);
 
-        if (
-          blockNumber <= lastBlockReceived.number &&
-          block.hash !== lastBlockReceived.hash
-        ) {
-          // This is a re-org, so process the block again
-          metrics.reorgsTotal.labels(chainId.toString()).inc();
-          log.info(`Re-org detected, re-processing block ${blockNumber}`);
-          metrics.reorgDepth
-            .labels(chainId.toString())
-            .set(lastBlockReceived.number - blockNumber + 1);
+          if (await isReorg(provider, lastBlockReceived, block)) {
+            // This is a re-org, so process the block again
+            metrics.reorgsTotal.labels(chainId.toString()).inc();
+            log.warn(`Re-org detected, re-processing block ${blockNumber}`);
+            metrics.reorgDepth.labels(chainId.toString()).set(1);
+          }
+          lastBlockReceived = block;
+
+          const events = await pollContractForEvents(
+            blockNumber,
+            blockNumber,
+            this
+          );
+
+          await processBlockAndPersist({
+            context: this,
+            block,
+            blockNumber,
+            events,
+            log,
+            provider,
+          });
+        } catch (error) {
+          log.error(`Error processing block ${blockNumber}`, error);
         }
-        lastBlockReceived = block;
-
-        const events = await pollContractForEvents(
-          blockNumber,
-          blockNumber,
-          this
-        );
-
-        await processBlockAndPersist({
-          context: this,
-          block,
-          blockNumber,
-          events,
-          log,
-          provider,
-        });
-      } catch (error) {
-        log.error(
-          `Error in pollContractForEvents for block ${blockNumber}`,
-          error
-        );
-      }
+      });
     });
 
     // We run a watchdog to check if we are receiving blocks. This determines if
@@ -668,4 +668,24 @@ function blockToRegistryBlock(block: ethers.providers.Block): RegistryBlock {
     timestamp: block.timestamp,
     hash: block.hash,
   };
+}
+
+export async function isReorg(
+  provider: providers.Provider,
+  previousBlock: providers.Block,
+  block: providers.Block
+): Promise<boolean> {
+  if (block.number <= previousBlock.number) {
+    return (
+      block.number === previousBlock.number && block.hash !== previousBlock.hash
+    );
+  }
+
+  if (block.number === previousBlock.number + 1) {
+    return block.parentHash !== previousBlock.hash;
+  }
+
+  return (
+    (await provider.getBlock(previousBlock.number)).hash !== previousBlock.hash
+  );
 }

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -363,6 +363,12 @@ export class ChainContext {
           log.debug("New block received");
 
           const block = await provider.getBlock(blockNumber);
+          const reorg = await isReorg(provider, lastBlockReceived, block);
+          if (!reorg && block.number < lastBlockReceived.number) {
+            log.debug(`Ignoring stale block ${block.number}`);
+            return;
+          }
+
           // Set the block time metric
           const _blockTime = block.timestamp - lastBlockReceived.timestamp;
           metrics.blockProducingRate.labels(chainId.toString()).set(_blockTime);
@@ -371,14 +377,13 @@ export class ChainContext {
             block.number
           );
 
-          if (await isReorg(provider, lastBlockReceived, block)) {
+          if (reorg) {
             metrics.reorgsTotal.labels(chainId.toString()).inc();
             log.warn(`Re-org detected at block ${blockNumber}`);
             metrics.reorgDepth
               .labels(chainId.toString())
               .set(Math.max(lastBlockReceived.number - block.number + 1, 1));
           }
-          lastBlockReceived = block;
 
           const events = await pollContractForEvents(fromBlock, toBlock, this);
 
@@ -390,6 +395,7 @@ export class ChainContext {
             log,
             provider,
           });
+          lastBlockReceived = block;
         } catch (error) {
           log.error(`Error processing block ${blockNumber}`, error);
         }
@@ -671,7 +677,7 @@ export async function isReorg(
   previousBlock: providers.Block,
   block: providers.Block
 ): Promise<boolean> {
-  if (block.number <= previousBlock.number) {
+  if (block.number === previousBlock.number) {
     return block.hash !== previousBlock.hash;
   }
 

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -363,28 +363,24 @@ export class ChainContext {
           log.debug("New block received");
 
           const block = await provider.getBlock(blockNumber);
-          if (block.number < lastBlockReceived.number) {
-            log.debug(`Ignoring stale block ${block.number}`);
-            return;
-          }
-
           // Set the block time metric
           const _blockTime = block.timestamp - lastBlockReceived.timestamp;
           metrics.blockProducingRate.labels(chainId.toString()).set(_blockTime);
+          const [fromBlock, toBlock] = getEventPollingRange(
+            lastBlockReceived.number,
+            block.number
+          );
 
           if (await isReorg(provider, lastBlockReceived, block)) {
-            // This is a re-org, so process the block again
             metrics.reorgsTotal.labels(chainId.toString()).inc();
-            log.warn(`Re-org detected, re-processing block ${blockNumber}`);
-            metrics.reorgDepth.labels(chainId.toString()).set(1);
+            log.warn(`Re-org detected at block ${blockNumber}`);
+            metrics.reorgDepth
+              .labels(chainId.toString())
+              .set(Math.max(lastBlockReceived.number - block.number + 1, 1));
           }
           lastBlockReceived = block;
 
-          const events = await pollContractForEvents(
-            blockNumber,
-            blockNumber,
-            this
-          );
+          const events = await pollContractForEvents(fromBlock, toBlock, this);
 
           await processBlockAndPersist({
             context: this,
@@ -676,9 +672,7 @@ export async function isReorg(
   block: providers.Block
 ): Promise<boolean> {
   if (block.number <= previousBlock.number) {
-    return (
-      block.number === previousBlock.number && block.hash !== previousBlock.hash
-    );
+    return block.hash !== previousBlock.hash;
   }
 
   if (block.number === previousBlock.number + 1) {
@@ -688,4 +682,11 @@ export async function isReorg(
   return (
     (await provider.getBlock(previousBlock.number)).hash !== previousBlock.hash
   );
+}
+
+export function getEventPollingRange(
+  previousBlockNumber: number,
+  blockNumber: number
+): [number, number] {
+  return [Math.min(previousBlockNumber + 1, blockNumber), blockNumber];
 }


### PR DESCRIPTION
# Description

Reorgs are being identified probably too often, even when they are not reorgs.

This change adds more granularity on the check, so simply blocks loaded out of order or missed are not counted as reorgs.

## How to test

Unit tests


----
AI generated description:

 ## What changed

  - Processes block notifications sequentially so provider calls cannot update the last-seen block out of order.
  - Detects reorgs using block hashes, parent hashes, and canonical-chain checks after block gaps.
  - Polls the full missing block range when notifications skip heights, preventing events in the gap from being missed.

  ## Why

  - Delayed or skipped block notifications could previously be counted as reorgs even when the processed block remained canonical, inflating reorg metrics.

  ## QA Testing

  Developer verification:

  - isReorg unit cases cover consecutive parent matches and mismatches, lower replacement heads, canonical and non-canonical gaps, and provider failures.
  - getEventPollingRange unit cases cover consecutive, skipped-height, and lower-block inputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved blockchain event processing across block ranges, helping ensure events are captured during gaps or rapidly advancing blocks.
  * Enhanced handling of chain reorganizations, including replacement blocks and non-canonical history.
  * Block updates are now processed sequentially for more consistent results.

* **Bug Fixes**
  * Improved error handling when block or network data cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->