### PR TITLE
fix: fix crashlooping causes

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,5 +80,6 @@
     "src/**/*.ts": [
       "npm run lint:fix --"
     ]
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
 }

--- a/package.json
+++ b/package.json
@@ -80,6 +80,5 @@
     "src/**/*.ts": [
       "npm run lint:fix --"
     ]
-  },
-  "packageManager": "yarn@1.22.22+sha1.ac34549e6aa8e7ead463a7407e1c7390f61a6610"
+  }
 }

--- a/src/commands/run.spec.ts
+++ b/src/commands/run.spec.ts
@@ -1,0 +1,137 @@
+import { initLogging } from "../utils";
+import { WarmUpChain, warmUpChains } from "./run";
+
+// These tests deliberately drive the failure path, which logs errors by design
+initLogging({ logLevel: "SILENT" });
+
+/** Tiny backoff so the tests don't wait out the production delays */
+const backoff = { attempts: 3, baseDelayMs: 1, maxDelayMs: 4 };
+
+const chain = (
+  chainId: number,
+  warmUp: (oneShot?: boolean) => Promise<unknown>
+): WarmUpChain & { markUnhealthy: jest.Mock } => ({
+  chainId,
+  warmUp: jest.fn(warmUp),
+  markUnhealthy: jest.fn(),
+});
+
+const healthy = (chainId: number, onWarmUp?: () => void) =>
+  chain(chainId, async () => {
+    // Resolve on a later tick so a sibling's synchronous rejection has every
+    // chance to abort us before we finish.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    onWarmUp?.();
+  });
+
+const broken = (chainId: number) =>
+  chain(chainId, async () => {
+    throw new Error("could not detect network");
+  });
+
+describe("warmUpChains", () => {
+  it("returns a zero exit code once every chain has warmed up", async () => {
+    const chains = [healthy(1), healthy(100), healthy(8453)];
+
+    await expect(warmUpChains(chains, { backoff })).resolves.toBe(0);
+    chains.forEach((c) => {
+      expect(c.warmUp).toHaveBeenCalledTimes(1);
+      expect(c.markUnhealthy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("passes the one-shot flag through to each chain", async () => {
+    const chains = [healthy(1), healthy(100)];
+
+    await warmUpChains(chains, { oneShot: true, backoff });
+
+    chains.forEach((c) => expect(c.warmUp).toHaveBeenCalledWith(true));
+  });
+
+  it("does not reject when a chain exhausts its warm-up retries", async () => {
+    // Regression: `Promise.all` used to propagate this rejection out of
+    // `run()`, which then exited the process and took every healthy chain
+    // down with the one broken RPC.
+    const chains = [broken(1), healthy(100), healthy(8453)];
+
+    await expect(warmUpChains(chains, { backoff })).resolves.not.toThrow();
+  });
+
+  it("still warms up healthy chains when a sibling chain fails", async () => {
+    const warmedUp: number[] = [];
+    const chains = [
+      broken(1),
+      healthy(100, () => warmedUp.push(100)),
+      healthy(8453, () => warmedUp.push(8453)),
+    ];
+
+    await warmUpChains(chains, { backoff });
+
+    // Both healthy chains ran to completion, and were awaited - the broken
+    // chain neither cancelled them nor let `warmUpChains` resolve early.
+    expect(warmedUp).toEqual([100, 8453]);
+    expect(chains[1].warmUp).toHaveBeenCalledTimes(1);
+    expect(chains[2].warmUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("only marks the failing chain unhealthy", async () => {
+    const chains = [broken(1), healthy(100), healthy(8453)];
+
+    await warmUpChains(chains, { backoff });
+
+    expect(chains[0].markUnhealthy).toHaveBeenCalled();
+    expect(chains[1].markUnhealthy).not.toHaveBeenCalled();
+    expect(chains[2].markUnhealthy).not.toHaveBeenCalled();
+  });
+
+  it("reports a non-zero exit code when a chain gives up", async () => {
+    // The failure is isolated, but it must not be silent: a run where nothing
+    // is being watched has to exit non-zero so the pod is restarted.
+    await expect(
+      warmUpChains([broken(1), healthy(100)], { backoff })
+    ).resolves.toBe(1);
+  });
+
+  it("retries a chain whose RPC is briefly unavailable", async () => {
+    let attempts = 0;
+    const flaky = chain(1, async () => {
+      attempts++;
+      if (attempts < backoff.attempts) throw new Error("rate limited");
+    });
+
+    await expect(
+      warmUpChains([flaky, healthy(100)], { backoff })
+    ).resolves.toBe(0);
+    expect(attempts).toBe(backoff.attempts);
+    expect(flaky.markUnhealthy).not.toHaveBeenCalled();
+  });
+
+  it("gives up on a chain after a bounded number of attempts", async () => {
+    const chains = [broken(1)];
+
+    await warmUpChains(chains, { backoff });
+
+    expect(chains[0].warmUp).toHaveBeenCalledTimes(backoff.attempts);
+  });
+
+  it("isolates a chain that rejects with a non-error value", async () => {
+    const weird = chain(1, async () => {
+      throw "boom"; // eslint-disable-line no-throw-literal
+    });
+
+    await expect(
+      warmUpChains([weird, healthy(100)], { backoff })
+    ).resolves.toBe(1);
+    expect(weird.markUnhealthy).toHaveBeenCalled();
+  });
+
+  it("keeps siblings alive when marking a chain unhealthy itself throws", async () => {
+    const chains = [broken(1), healthy(100)];
+    chains[0].markUnhealthy.mockImplementation(() => {
+      throw new Error("metrics registry blew up");
+    });
+
+    await expect(warmUpChains(chains, { backoff })).resolves.toBe(1);
+    expect(chains[1].warmUp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,11 +1,141 @@
 import { RunOptions } from "../types";
-import { getLogger } from "../utils";
+import {
+  getLogger,
+  LoggerWithMethods,
+  RetryOptions,
+  withRetry,
+} from "../utils";
 import { DBService, ApiService, ChainContext } from "../services";
 
 // How often to log the process memory usage. This leaves a memory trail in the
 // logs so a restart can be correlated with memory pressure (e.g. OOM) even when
 // only the application logs are available.
 const MEMORY_LOG_INTERVAL_MS = 60_000;
+
+type WarmUpBackoff = Required<
+  Pick<RetryOptions, "attempts" | "baseDelayMs" | "maxDelayMs">
+>;
+
+/**
+ * How hard to try warming a chain up before abandoning it.
+ *
+ * `ChainContext.warmUp` already retries each individual RPC call, so reaching
+ * here means that chain's endpoint has been unusable for a while. Retry the
+ * whole warm-up on top of that, bounded, so an RPC outage lasting a couple of
+ * minutes resolves itself without a restart: 5s, 10s, 20s, 40s.
+ */
+const WARM_UP_BACKOFF: WarmUpBackoff = {
+  attempts: 5,
+  baseDelayMs: 5_000,
+  maxDelayMs: 60_000,
+};
+
+/** The slice of `ChainContext` that warm-up supervision depends on */
+export interface WarmUpChain {
+  chainId: number;
+  warmUp(oneShot?: boolean): Promise<unknown>;
+  /** Flag the chain as out of sync so `/health` stops reporting it healthy */
+  markUnhealthy(): void;
+}
+
+export interface WarmUpOptions {
+  oneShot?: boolean;
+  /** Overridable so tests don't have to wait out the production backoff */
+  backoff?: WarmUpBackoff;
+}
+
+/**
+ * Warm every chain up concurrently, containing failures to the chain that
+ * caused them.
+ *
+ * `warmUp` throws once a chain has exhausted the retries on one of its RPC
+ * calls. That rejection used to travel through `Promise.all` into `run()`'s
+ * catch block, which exited the process - so a single unreachable endpoint took
+ * down every healthy chain with it, over and over. Each chain is now retried on
+ * its own with bounded backoff, and one that never comes up is marked unhealthy
+ * and left behind rather than aborting its siblings.
+ *
+ * @returns the exit code for the run: non-zero if any chain was abandoned.
+ */
+export async function warmUpChains(
+  chains: WarmUpChain[],
+  options: WarmUpOptions = {}
+): Promise<number> {
+  const log = getLogger({ name: "commands:warmUpChains" });
+  const { oneShot, backoff = WARM_UP_BACKOFF } = options;
+
+  // `allSettled` rather than `all`: `warmUpChain` is written not to throw, but
+  // the whole point of this function is that no single chain can abort the
+  // others, so don't rely on that holding.
+  const results = await Promise.allSettled(
+    chains.map((chain) => warmUpChain(chain, oneShot, backoff, log))
+  );
+
+  const failed = results.filter((result) => {
+    if (result.status === "rejected") {
+      log.error(
+        "Unexpected error thrown while warming up a chain",
+        result.reason
+      );
+      return true;
+    }
+    return !result.value;
+  });
+
+  if (failed.length > 0) {
+    // Healthy chains keep running; this only decides the code the process
+    // eventually exits with, which for a long-running watcher means every
+    // chain was abandoned and there is nothing left to watch.
+    log.error(
+      `${failed.length} of ${chains.length} chains could not be warmed up`
+    );
+    return 1;
+  }
+
+  return 0;
+}
+
+/**
+ * Warm a single chain up, retrying with bounded backoff.
+ * @returns whether the chain was warmed up successfully.
+ */
+async function warmUpChain(
+  chain: WarmUpChain,
+  oneShot: boolean | undefined,
+  backoff: WarmUpBackoff,
+  log: LoggerWithMethods
+): Promise<boolean> {
+  const { chainId } = chain;
+
+  try {
+    await withRetry(() => chain.warmUp(oneShot), {
+      ...backoff,
+      onRetry: (attempt, error, delayMs) =>
+        log.warn(
+          `Chain ${chainId} failed to warm up (attempt ${attempt}/${backoff.attempts}), retrying in ${delayMs}ms`,
+          error
+        ),
+    });
+    return true;
+  } catch (error) {
+    log.error(
+      `Chain ${chainId} gave up warming up after ${backoff.attempts} attempts. Check the RPC.`,
+      error
+    );
+
+    // Flag the chain so `/health` fails and the pod is restarted by its
+    // liveness probe, instead of exiting the process from under the chains
+    // that are working. Guarded so a broken chain cannot take out the rest
+    // through the very code that is supposed to isolate it.
+    try {
+      chain.markUnhealthy();
+    } catch (markError) {
+      log.error(`Could not mark chain ${chainId} as unhealthy`, markError);
+    }
+
+    return false;
+  }
+}
 
 /**
  * Run the watch-tower 👀🐮
@@ -70,13 +200,9 @@ export async function run(options: RunOptions) {
     // Set the chain contexts on the API server
     api?.setChainContexts(chainContexts);
 
-    // Run the block watcher after warm up for each chain
-    const runPromises = chainContexts.map(async (context) => {
-      return context.warmUp(oneShot);
-    });
-
-    // Run all the chain contexts
-    await Promise.all(runPromises);
+    // Warm up each chain and then run its block watcher. Failures are
+    // contained per chain, so a bad RPC endpoint cannot stop the others.
+    exitCode = await warmUpChains(chainContexts, { oneShot });
   } catch (error) {
     log.error("Unexpected error thrown when running watchtower", error);
     exitCode = 1;

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -172,6 +172,19 @@ export async function checkForAndPlaceOrder(
   const log = getLogger(loggerParams);
   log.debug(`The registry has ${numOwners} owners and ${numOrders} orders`);
 
+  // Evict discrete orders that can no longer be placed. `orders` is otherwise
+  // append-only and dominates the persisted payload, which every write pays
+  // for twice - once to `JSON.stringify` and once to write to LevelDB.
+  //
+  // This is a whole-registry scan, so it runs once per block rather than
+  // inside `write()`. It must happen before the loop below, because that also
+  // writes every CHUNK_SIZE orders - pruning afterwards would leave the first
+  // post-deploy chunks serialising the full expired registry.
+  const pruned = registry.prune(blockTimestamp);
+  if (pruned > 0) {
+    log.debug(`Pruned ${pruned} expired discrete orders`);
+  }
+
   for (const [owner, conditionalOrders] of ownerOrders.entries()) {
     ownerCounter++;
     const log = getLogger({
@@ -325,17 +338,6 @@ export async function checkForAndPlaceOrder(
       ownerOrders.delete(owner);
       metrics.activeOwnersTotal.labels(chainId.toString()).dec();
     }
-  }
-
-  // Evict discrete orders that can no longer be placed. `orders` is otherwise
-  // append-only and dominates the persisted payload, which every write pays
-  // for twice - once to `JSON.stringify` and once to write to LevelDB.
-  //
-  // This is a whole-registry scan, so it runs once per block here rather than
-  // inside `write()`, which is also called on every CHUNK_SIZE orders.
-  const pruned = registry.prune(blockTimestamp);
-  if (pruned > 0) {
-    log.debug(`Pruned ${pruned} expired discrete orders`);
   }
 
   // save the registry - don't catch errors here, as it's now a docker container

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -130,10 +130,16 @@ const CHUNK_SIZE = 50; // How many orders to process before saving
 
 /**
  * Upper bound on a single `sendOrder` call, including the SDK's internal
- * retries. Comfortably above the observed p99 (~3s) but far below the
- * watchdog timeout, so a wedged socket can't stall block processing.
+ * retries.
+ *
+ * Must stay below `WATCHDOG_TIMEOUT_DEFAULT_SECS` so one wedged socket cannot
+ * on its own push the chain watcher past the watchdog deadline. Still ~6x the
+ * observed p99 (~3.4s), leaving room for the SDK to retry transport failures.
+ *
+ * Note this bounds a *single* call, not a whole block pass - a pass posting
+ * many orders can still exceed the watchdog if each one is slow.
  */
-const ORDER_BOOK_API_TIMEOUT_MS = 60_000;
+export const ORDER_BOOK_API_TIMEOUT_MS = 40_000;
 
 /**
  * Watch for new blocks and check for orders to place
@@ -319,6 +325,17 @@ export async function checkForAndPlaceOrder(
       ownerOrders.delete(owner);
       metrics.activeOwnersTotal.labels(chainId.toString()).dec();
     }
+  }
+
+  // Evict discrete orders that can no longer be placed. `orders` is otherwise
+  // append-only and dominates the persisted payload, which every write pays
+  // for twice - once to `JSON.stringify` and once to write to LevelDB.
+  //
+  // This is a whole-registry scan, so it runs once per block here rather than
+  // inside `write()`, which is also called on every CHUNK_SIZE orders.
+  const pruned = registry.prune(blockTimestamp);
+  if (pruned > 0) {
+    log.debug(`Pruned ${pruned} expired discrete orders`);
   }
 
   // save the registry - don't catch errors here, as it's now a docker container
@@ -567,7 +584,7 @@ export const _printUnfilledOrders = (orders: Map<BytesLike, OrderStatus>) => {
  * @param order to be placed on the cow protocol api
  * @param apiUrl rest api url
  */
-async function postDiscreteOrder(params: {
+export async function postDiscreteOrder(params: {
   conditionalOrder: ConditionalOrder;
   orderUid: string;
   order: any;
@@ -677,8 +694,9 @@ async function postDiscreteOrder(params: {
       // http.ClientRequest in node.js
       reasonError += `Unresponsive API: ${error.request}`;
     } else if (error.message) {
-      // Something happened in setting up the request that triggered an Error
-      reasonError += `. Internal Error: ${error.request}`;
+      // Something happened in setting up the request that triggered an Error,
+      // including a `TimeoutError` from the `withTimeout` wrapper.
+      reasonError += `. Internal Error: ${error.message}`;
     } else {
       reasonError += `. Unhandled Error: ${error.message}`;
     }

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -32,6 +32,7 @@ import {
   getLogger,
   handleOnChainCustomError,
   metrics,
+  withTimeout,
 } from "../../utils";
 import { badOrder, policy } from "./filtering";
 import { pollConditionalOrder } from "./poll";
@@ -72,6 +73,37 @@ const API_ERRORS_BACKOFF: BackOffApiErrorsDelays = {
   [ApiErrors.INVALID_APP_DATA]: ONE_MIN, // Give the user some time to upload the correct appData
 };
 
+/** How many times to retry on the very next block before backing off */
+const TRY_NEXT_BLOCK_MAX_ATTEMPTS = 2;
+/** Backoff applied once `TRY_NEXT_BLOCK_MAX_ATTEMPTS` is exhausted */
+const ESCALATING_BACKOFF_DELAYS = [ONE_MIN, TEN_MINS, ONE_HOUR];
+
+/**
+ * Escalating backoff for API errors that are *usually* transient but, when
+ * they aren't, would otherwise be retried on every single block forever.
+ *
+ * @param consecutiveFailures how many times in a row this order has failed,
+ * including the current failure
+ * @returns seconds to wait before the next attempt, or `undefined` to retry on
+ * the next block
+ */
+export function escalatingRetryDelay(
+  consecutiveFailures: number
+): number | undefined {
+  if (consecutiveFailures <= TRY_NEXT_BLOCK_MAX_ATTEMPTS) {
+    return undefined;
+  }
+
+  const delay =
+    ESCALATING_BACKOFF_DELAYS[
+      consecutiveFailures - TRY_NEXT_BLOCK_MAX_ATTEMPTS - 1
+    ];
+
+  return (
+    delay ?? ESCALATING_BACKOFF_DELAYS[ESCALATING_BACKOFF_DELAYS.length - 1]
+  );
+}
+
 const API_ERRORS_DROP: DropApiErrorsArray = [
   ApiErrors.SELL_AMOUNT_OVERFLOW, // Implies a `feeAmount` has been set and `sellAmount` + `feeAmount` > `type(uint256).max`
   ApiErrors.TRANSFER_SIMULATION_FAILED, // Sell token can't be transferred, drop it
@@ -95,6 +127,13 @@ const API_ERRORS_DROP: DropApiErrorsArray = [
 // ApiErrors.AppDataHashMismatch - we never submit full appData
 
 const CHUNK_SIZE = 50; // How many orders to process before saving
+
+/**
+ * Upper bound on a single `sendOrder` call, including the SDK's internal
+ * retries. Comfortably above the observed p99 (~3s) but far below the
+ * watchdog timeout, so a wedged socket can't stall block processing.
+ */
+const ORDER_BOOK_API_TIMEOUT_MS = 60_000;
 
 /**
  * Watch for new blocks and check for orders to place
@@ -587,23 +626,41 @@ async function postDiscreteOrder(params: {
     );
     log.debug(`Post order ${orderUid} details`, postOrder);
     if (!dryRun) {
-      const orderUid = await orderBookApi.sendOrder(postOrder);
+      const orderUid = await withTimeout(
+        orderBookApi.sendOrder(postOrder),
+        ORDER_BOOK_API_TIMEOUT_MS,
+        `sendOrder (ID=${conditionalOrder.id})`
+      );
       metrics.orderBookDiscreteOrdersTotal.labels(...metricLabels).inc();
       log.info(`API response`, { orderUid });
     }
+
+    // The order was accepted, so any previous backoff no longer applies
+    conditionalOrder.consecutiveApiFailures = 0;
   } catch (error: any) {
     let reasonError = "Error placing order in API";
     if (error.response) {
       const { status } = error.response;
       const { body } = error;
 
+      const consecutiveFailures =
+        (conditionalOrder.consecutiveApiFailures ?? 0) + 1;
+      conditionalOrder.consecutiveApiFailures = consecutiveFailures;
+
       const handleErrorResult = handleOrderBookError(
         status,
         body,
         error,
         blockTimestamp,
-        metricLabels
+        metricLabels,
+        consecutiveFailures
       );
+
+      // A duplicated order means it is already in the orderbook - treat that
+      // as acceptance so we don't back off a perfectly healthy order.
+      if (handleErrorResult.result === PollResultCode.SUCCESS) {
+        conditionalOrder.consecutiveApiFailures = 0;
+      }
       const isHandled = HANDLED_RESULT_CODES.includes(handleErrorResult.result);
       const logLevel = isHandled ? "info" : "error";
       log[logLevel](
@@ -636,12 +693,13 @@ async function postDiscreteOrder(params: {
   return { result: PollResultCode.SUCCESS };
 }
 
-function handleOrderBookError(
+export function handleOrderBookError(
   status: any,
   body: any,
   error: any,
   blockTimestamp: number,
-  metricLabels: string[]
+  metricLabels: string[],
+  consecutiveFailures: number
 ): Omit<PollResultSuccess, "order" | "signature"> | PollResultErrors {
   const apiError = body?.errorType as OrderPostError.errorType;
   metrics.orderBookErrorsTotal
@@ -673,11 +731,27 @@ function handleOrderBookError(
         };
       }
 
-      // Handle some errors, that might be solved in the next block
+      // Handle some errors, that might be solved in the next block. These are
+      // only *usually* transient though - an order with a permanently invalid
+      // signature would otherwise be re-posted on every block forever, so back
+      // off progressively the longer it keeps failing.
       if (API_ERRORS_TRY_NEXT_BLOCK.includes(apiError)) {
+        const reason = `OrderBook API Known Error: ${apiError}, ${body?.description}`;
+        const retryDelay = escalatingRetryDelay(consecutiveFailures);
+
+        if (retryDelay === undefined) {
+          return { result: PollResultCode.TRY_NEXT_BLOCK, reason };
+        }
+
+        const nextPollTimestamp = blockTimestamp + retryDelay;
         return {
-          result: PollResultCode.TRY_NEXT_BLOCK,
-          reason: `OrderBook API Known Error: ${apiError}, ${body?.description}`,
+          result: PollResultCode.TRY_AT_EPOCH,
+          epoch: nextPollTimestamp,
+          reason: `${reason}. Failed ${consecutiveFailures} times in a row, scheduling next polling in ${Math.floor(
+            retryDelay / 60
+          )} minutes, at ${nextPollTimestamp} ${formatEpoch(
+            nextPollTimestamp
+          )}`,
         };
       }
 

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -156,6 +156,9 @@ const API_ERRORS_DROP: DropApiErrorsArray = [
 
 const CHUNK_SIZE = 50; // How many orders to process before saving
 
+/** `lastApiError` value used to scope a run of consecutive request timeouts */
+const TIMEOUT_ERROR_KEY = "Timeout";
+
 /**
  * Upper bound on a single `sendOrder` call, including the SDK's internal
  * retries.
@@ -247,6 +250,13 @@ export async function checkForAndPlaceOrder(
 
         // Save the registry after processing each chunk
         await registry.write();
+      }
+
+      // Orders persisted before `createdAtEpoch` existed have no age, which
+      // would exempt them from the presign cut-off forever. Stamp them on
+      // first sight so the clock starts now rather than never.
+      if (conditionalOrder.createdAtEpoch === undefined) {
+        conditionalOrder.createdAtEpoch = blockTimestamp;
       }
 
       const logOrderDetails = `Processing order ${orderCounter}/${numOrders} with ID ${conditionalOrder.id} from TX ${conditionalOrder.tx} with params:`;
@@ -684,6 +694,7 @@ export async function postDiscreteOrder(params: {
 
     // The order was accepted, so any previous backoff no longer applies
     conditionalOrder.consecutiveApiFailures = 0;
+    conditionalOrder.lastApiError = undefined;
   } catch (error: any) {
     let reasonError = "Error placing order in API";
 
@@ -694,8 +705,11 @@ export async function postDiscreteOrder(params: {
     // once per block.
     if (error instanceof TimeoutError) {
       const consecutiveFailures =
-        (conditionalOrder.consecutiveApiFailures ?? 0) + 1;
+        conditionalOrder.lastApiError === TIMEOUT_ERROR_KEY
+          ? (conditionalOrder.consecutiveApiFailures ?? 0) + 1
+          : 1;
       conditionalOrder.consecutiveApiFailures = consecutiveFailures;
+      conditionalOrder.lastApiError = TIMEOUT_ERROR_KEY;
 
       metrics.orderBookErrorsTotal
         .labels(...metricLabels, "timeout", "Timeout")
@@ -713,9 +727,16 @@ export async function postDiscreteOrder(params: {
       const { status } = error.response;
       const { body } = error;
 
+      // The backoff tiers mean "this order keeps failing the same way", so a
+      // different rejection restarts the count rather than inheriting the
+      // penalty accrued by an unrelated error.
+      const apiError = body?.errorType as string | undefined;
       const consecutiveFailures =
-        (conditionalOrder.consecutiveApiFailures ?? 0) + 1;
+        conditionalOrder.lastApiError === apiError
+          ? (conditionalOrder.consecutiveApiFailures ?? 0) + 1
+          : 1;
       conditionalOrder.consecutiveApiFailures = consecutiveFailures;
+      conditionalOrder.lastApiError = apiError;
 
       const handleErrorResult = handleOrderBookError(
         status,
@@ -730,6 +751,7 @@ export async function postDiscreteOrder(params: {
       // as acceptance so we don't back off a perfectly healthy order.
       if (handleErrorResult.result === PollResultCode.SUCCESS) {
         conditionalOrder.consecutiveApiFailures = 0;
+        conditionalOrder.lastApiError = undefined;
       }
       const isHandled = HANDLED_RESULT_CODES.includes(handleErrorResult.result);
       const logLevel = isHandled ? "info" : "error";
@@ -803,9 +825,9 @@ export function handleOrderBookError(
       }
 
       // Handle some errors, that might be solved in the next block. These are
-      // only *usually* transient though - an order with a permanently invalid
-      // signature would otherwise be re-posted on every block forever, so back
-      // off progressively the longer it keeps failing.
+      // only *usually* transient though - an order that keeps being rejected
+      // would otherwise be re-posted on every block forever, so back off
+      // progressively the longer it keeps failing.
       if (API_ERRORS_TRY_NEXT_BLOCK.includes(apiError)) {
         return escalatingRetryResult(
           consecutiveFailures,

--- a/src/domain/polling/index.ts
+++ b/src/domain/polling/index.ts
@@ -32,6 +32,7 @@ import {
   getLogger,
   handleOnChainCustomError,
   metrics,
+  TimeoutError,
   withTimeout,
 } from "../../utils";
 import { badOrder, policy } from "./filtering";
@@ -102,6 +103,33 @@ export function escalatingRetryDelay(
   return (
     delay ?? ESCALATING_BACKOFF_DELAYS[ESCALATING_BACKOFF_DELAYS.length - 1]
   );
+}
+
+/**
+ * Map a consecutive failure count onto the escalating retry progression: retry
+ * on the next block while the failure may still be transient, then back off by
+ * increasing amounts.
+ */
+function escalatingRetryResult(
+  consecutiveFailures: number,
+  blockTimestamp: number,
+  reason: string
+): Omit<PollResultSuccess, "order" | "signature"> | PollResultErrors {
+  const retryDelay = escalatingRetryDelay(consecutiveFailures);
+
+  if (retryDelay === undefined) {
+    return { result: PollResultCode.TRY_NEXT_BLOCK, reason };
+  }
+
+  const nextPollTimestamp = blockTimestamp + retryDelay;
+
+  return {
+    result: PollResultCode.TRY_AT_EPOCH,
+    epoch: nextPollTimestamp,
+    reason: `${reason}. Failed ${consecutiveFailures} times in a row, scheduling next polling in ${Math.floor(
+      retryDelay / 60
+    )} minutes, at ${nextPollTimestamp} ${formatEpoch(nextPollTimestamp)}`,
+  };
 }
 
 const API_ERRORS_DROP: DropApiErrorsArray = [
@@ -658,6 +686,29 @@ export async function postDiscreteOrder(params: {
     conditionalOrder.consecutiveApiFailures = 0;
   } catch (error: any) {
     let reasonError = "Error placing order in API";
+
+    // A timeout carries no response to classify, but it is still a transient
+    // orderbook failure. Back it off on the same progression as one, rather
+    // than reporting an unexpected error and retrying on every block - if the
+    // API is unreachable, every order would otherwise pay the full timeout
+    // once per block.
+    if (error instanceof TimeoutError) {
+      const consecutiveFailures =
+        (conditionalOrder.consecutiveApiFailures ?? 0) + 1;
+      conditionalOrder.consecutiveApiFailures = consecutiveFailures;
+
+      metrics.orderBookErrorsTotal
+        .labels(...metricLabels, "timeout", "Timeout")
+        .inc();
+      log.info(`Unable to place order in API. Result: timeout`, error.message);
+
+      return escalatingRetryResult(
+        consecutiveFailures,
+        blockTimestamp,
+        `OrderBook API timeout: ${error.message}`
+      );
+    }
+
     if (error.response) {
       const { status } = error.response;
       const { body } = error;
@@ -756,23 +807,11 @@ export function handleOrderBookError(
       // signature would otherwise be re-posted on every block forever, so back
       // off progressively the longer it keeps failing.
       if (API_ERRORS_TRY_NEXT_BLOCK.includes(apiError)) {
-        const reason = `OrderBook API Known Error: ${apiError}, ${body?.description}`;
-        const retryDelay = escalatingRetryDelay(consecutiveFailures);
-
-        if (retryDelay === undefined) {
-          return { result: PollResultCode.TRY_NEXT_BLOCK, reason };
-        }
-
-        const nextPollTimestamp = blockTimestamp + retryDelay;
-        return {
-          result: PollResultCode.TRY_AT_EPOCH,
-          epoch: nextPollTimestamp,
-          reason: `${reason}. Failed ${consecutiveFailures} times in a row, scheduling next polling in ${Math.floor(
-            retryDelay / 60
-          )} minutes, at ${nextPollTimestamp} ${formatEpoch(
-            nextPollTimestamp
-          )}`,
-        };
+        return escalatingRetryResult(
+          consecutiveFailures,
+          blockTimestamp,
+          `OrderBook API Known Error: ${apiError}, ${body?.description}`
+        );
       }
 
       // Drop orders that have some element of invalidity

--- a/src/domain/polling/polling.spec.ts
+++ b/src/domain/polling/polling.spec.ts
@@ -1,0 +1,61 @@
+import { escalatingRetryDelay, handleOrderBookError } from ".";
+import { PollResultCode } from "@cowprotocol/sdk-composable";
+
+describe("escalatingRetryDelay", () => {
+  it("retries on the next block for the first two failures", () => {
+    expect(escalatingRetryDelay(1)).toBeUndefined();
+    expect(escalatingRetryDelay(2)).toBeUndefined();
+  });
+
+  it("backs off for a minute on the third consecutive failure", () => {
+    expect(escalatingRetryDelay(3)).toBe(60);
+  });
+
+  it("backs off for ten minutes on the fourth consecutive failure", () => {
+    expect(escalatingRetryDelay(4)).toBe(600);
+  });
+
+  it("settles on an hourly retry once the order is clearly broken", () => {
+    expect(escalatingRetryDelay(5)).toBe(3600);
+    expect(escalatingRetryDelay(99)).toBe(3600);
+  });
+});
+
+describe("handleOrderBookError", () => {
+  const NOW = 1_784_857_003;
+  const LABELS = ["8453", "0xhandler", "0xowner", "0xid"];
+  const invalidSignature = {
+    errorType: "InvalidEip1271Signature",
+    description: "signature for computed order has bad format",
+  };
+
+  const handle = (consecutiveFailures: number) =>
+    handleOrderBookError(
+      400,
+      invalidSignature,
+      new Error("api"),
+      NOW,
+      LABELS,
+      consecutiveFailures
+    );
+
+  it("retries on the next block while the failure may still be transient", () => {
+    expect(handle(1)).toMatchObject({
+      result: PollResultCode.TRY_NEXT_BLOCK,
+    });
+  });
+
+  it("backs off once the same failure keeps repeating", () => {
+    expect(handle(3)).toMatchObject({
+      result: PollResultCode.TRY_AT_EPOCH,
+      epoch: NOW + 60,
+    });
+  });
+
+  it("escalates to an hourly retry for a persistently broken order", () => {
+    expect(handle(9)).toMatchObject({
+      result: PollResultCode.TRY_AT_EPOCH,
+      epoch: NOW + 3600,
+    });
+  });
+});

--- a/src/domain/polling/polling.spec.ts
+++ b/src/domain/polling/polling.spec.ts
@@ -7,7 +7,7 @@ import {
 } from ".";
 import { ConditionalOrder, OrderStatus, Registry } from "../../types";
 import { WATCHDOG_TIMEOUT_DEFAULT_SECS } from "../../services/chain";
-import { initLogging } from "../../utils";
+import { initLogging, withTimeout } from "../../utils";
 import { PollResultCode } from "@cowprotocol/sdk-composable";
 
 describe("escalatingRetryDelay", () => {
@@ -80,9 +80,12 @@ describe("ORDER_BOOK_API_TIMEOUT_MS", () => {
 describe("postDiscreteOrder", () => {
   initLogging({});
 
-  const post = (sendOrder: jest.Mock) =>
+  const post = (
+    sendOrder: jest.Mock,
+    conditionalOrder: ConditionalOrder = { id: "0xid" } as ConditionalOrder
+  ) =>
     postDiscreteOrder({
-      conditionalOrder: { id: "0xid" } as never,
+      conditionalOrder,
       orderUid: "0xuid",
       order: {
         kind: "sell",
@@ -100,6 +103,35 @@ describe("postDiscreteOrder", () => {
       ownerNumber: 1,
       orderNumber: 1,
     });
+
+  // A promise that outlives its deadline, producing a real `TimeoutError`
+  const timesOut = () =>
+    jest.fn(() => withTimeout(new Promise(() => undefined), 1, "sendOrder"));
+
+  it("backs off a timed-out post instead of reporting an unexpected error", async () => {
+    const conditionalOrder = { id: "0xid" } as ConditionalOrder;
+
+    const result = await post(timesOut(), conditionalOrder);
+
+    expect(result.result).not.toBe(PollResultCode.UNEXPECTED_ERROR);
+    expect(result).toMatchObject({ result: PollResultCode.TRY_NEXT_BLOCK });
+    expect(conditionalOrder.consecutiveApiFailures).toBe(1);
+  });
+
+  it("escalates repeated timeouts onto the same backoff progression", async () => {
+    const conditionalOrder = {
+      id: "0xid",
+      consecutiveApiFailures: 2,
+    } as ConditionalOrder;
+
+    const result = await post(timesOut(), conditionalOrder);
+
+    expect(result).toMatchObject({
+      result: PollResultCode.TRY_AT_EPOCH,
+      epoch: 1_784_857_003 + 60,
+    });
+    expect(conditionalOrder.consecutiveApiFailures).toBe(3);
+  });
 
   it("reports why a non-response failure happened instead of 'undefined'", async () => {
     const sendOrder = jest.fn().mockRejectedValue(new Error("socket hang up"));

--- a/src/domain/polling/polling.spec.ts
+++ b/src/domain/polling/polling.spec.ts
@@ -1,4 +1,11 @@
-import { escalatingRetryDelay, handleOrderBookError } from ".";
+import {
+  ORDER_BOOK_API_TIMEOUT_MS,
+  escalatingRetryDelay,
+  handleOrderBookError,
+  postDiscreteOrder,
+} from ".";
+import { WATCHDOG_TIMEOUT_DEFAULT_SECS } from "../../services/chain";
+import { initLogging } from "../../utils";
 import { PollResultCode } from "@cowprotocol/sdk-composable";
 
 describe("escalatingRetryDelay", () => {
@@ -57,5 +64,47 @@ describe("handleOrderBookError", () => {
       result: PollResultCode.TRY_AT_EPOCH,
       epoch: NOW + 3600,
     });
+  });
+});
+
+describe("ORDER_BOOK_API_TIMEOUT_MS", () => {
+  it("bounds a single orderbook call below the default watchdog deadline", () => {
+    expect(ORDER_BOOK_API_TIMEOUT_MS).toBeLessThan(
+      WATCHDOG_TIMEOUT_DEFAULT_SECS * 1000
+    );
+  });
+});
+
+describe("postDiscreteOrder", () => {
+  initLogging({});
+
+  const post = (sendOrder: jest.Mock) =>
+    postDiscreteOrder({
+      conditionalOrder: { id: "0xid" } as never,
+      orderUid: "0xuid",
+      order: {
+        kind: "sell",
+        sellAmount: 1n,
+        buyAmount: 1n,
+        feeAmount: 0n,
+        validTo: 0,
+      },
+      orderBookApi: { sendOrder } as never,
+      blockTimestamp: 1_784_857_003,
+      dryRun: false,
+      metricLabels: ["8453", "0xhandler", "0xowner", "0xid"],
+      chainId: 8453 as never,
+      blockNumber: 1,
+      ownerNumber: 1,
+      orderNumber: 1,
+    });
+
+  it("reports why a non-response failure happened instead of 'undefined'", async () => {
+    const sendOrder = jest.fn().mockRejectedValue(new Error("socket hang up"));
+
+    const result = await post(sendOrder);
+
+    expect(result).toMatchObject({ result: PollResultCode.UNEXPECTED_ERROR });
+    expect((result as { reason: string }).reason).toContain("socket hang up");
   });
 });

--- a/src/domain/polling/polling.spec.ts
+++ b/src/domain/polling/polling.spec.ts
@@ -10,6 +10,8 @@ import { WATCHDOG_TIMEOUT_DEFAULT_SECS } from "../../services/chain";
 import { initLogging, withTimeout } from "../../utils";
 import { PollResultCode } from "@cowprotocol/sdk-composable";
 
+initLogging({});
+
 describe("escalatingRetryDelay", () => {
   it("retries on the next block for the first two failures", () => {
     expect(escalatingRetryDelay(1)).toBeUndefined();
@@ -33,15 +35,18 @@ describe("escalatingRetryDelay", () => {
 describe("handleOrderBookError", () => {
   const NOW = 1_784_857_003;
   const LABELS = ["8453", "0xhandler", "0xowner", "0xid"];
-  const invalidSignature = {
-    errorType: "InvalidEip1271Signature",
-    description: "signature for computed order has bad format",
+  // A transient-but-possibly-permanent error. Note this is deliberately *not*
+  // `InvalidEip1271Signature`, which is exempt from the escalating backoff
+  // because pending presign orders return it legitimately for days.
+  const quoteNotFound = {
+    errorType: "QuoteNotFound",
+    description: "no quote found for the order",
   };
 
   const handle = (consecutiveFailures: number) =>
     handleOrderBookError(
       400,
-      invalidSignature,
+      quoteNotFound,
       new Error("api"),
       NOW,
       LABELS,
@@ -78,8 +83,6 @@ describe("ORDER_BOOK_API_TIMEOUT_MS", () => {
 });
 
 describe("postDiscreteOrder", () => {
-  initLogging({});
-
   const post = (
     sendOrder: jest.Mock,
     conditionalOrder: ConditionalOrder = { id: "0xid" } as ConditionalOrder
@@ -122,6 +125,7 @@ describe("postDiscreteOrder", () => {
     const conditionalOrder = {
       id: "0xid",
       consecutiveApiFailures: 2,
+      lastApiError: "Timeout",
     } as ConditionalOrder;
 
     const result = await post(timesOut(), conditionalOrder);
@@ -204,7 +208,133 @@ describe("checkForAndPlaceOrder chunked writes", () => {
       timestamp: NOW_EPOCH,
     } as never).catch(() => undefined);
 
+    // This assertion is load-bearing: it proves the chunked write at
+    // updatedCount === 51 actually fired, so the check below is meaningful.
     expect(persisted.length).toBeGreaterThan(1);
     expect(persisted[0]).not.toContain(expiredUid(0));
+  });
+
+  it("stamps orders that predate createdAtEpoch so their age is knowable", async () => {
+    const registry = buildRegistry([]);
+
+    const context = {
+      chainId: 8453,
+      registry,
+      filterPolicy: undefined,
+      provider: { _isProvider: true },
+      orderBookApi: {},
+      dryRun: true,
+      contract: {},
+      multicall: {},
+    } as never;
+
+    await checkForAndPlaceOrder(context, {
+      number: 1,
+      timestamp: NOW_EPOCH,
+    } as never).catch(() => undefined);
+
+    const stamped = [...registry.ownerOrders.values()]
+      .flatMap((orders) => [...orders])
+      .map((order) => order.createdAtEpoch);
+    expect(stamped).toEqual(Array(ORDER_COUNT).fill(NOW_EPOCH));
+  });
+});
+
+describe("postDiscreteOrder - presign age", () => {
+  const NOW = 1_784_857_003;
+  const DAY = 24 * 60 * 60;
+
+  const rejectsWithInvalidSignature = () =>
+    jest.fn().mockRejectedValue(
+      Object.assign(new Error("api"), {
+        response: { status: 400 },
+        body: {
+          errorType: "InvalidEip1271Signature",
+          description: "signature for computed order has bad format",
+        },
+      })
+    );
+
+  const postAged = (createdAtEpoch?: number) =>
+    postDiscreteOrder({
+      conditionalOrder: { id: "0xid", createdAtEpoch } as ConditionalOrder,
+      orderUid: "0xuid",
+      order: { kind: "sell", sellAmount: 1n, buyAmount: 1n, feeAmount: 0n },
+      orderBookApi: { sendOrder: rejectsWithInvalidSignature() } as never,
+      blockTimestamp: NOW,
+      dryRun: false,
+      metricLabels: ["8453", "0xhandler", "0xowner", "0xid"],
+      chainId: 8453 as never,
+      blockNumber: 1,
+      ownerNumber: 1,
+      orderNumber: 1,
+    });
+
+  it("keeps polling a presign order still inside the window", async () => {
+    await expect(postAged(NOW - 2 * DAY)).resolves.toMatchObject({
+      result: PollResultCode.TRY_NEXT_BLOCK,
+    });
+  });
+});
+
+describe("postDiscreteOrder - failure counter scoping", () => {
+  const NOW = 1_784_857_003;
+
+  const rejectsWith = (errorType: string) =>
+    jest.fn().mockRejectedValue(
+      Object.assign(new Error("api"), {
+        response: { status: 400 },
+        body: { errorType, description: "d" },
+      })
+    );
+
+  const postWith = (conditionalOrder: ConditionalOrder, sendOrder: jest.Mock) =>
+    postDiscreteOrder({
+      conditionalOrder,
+      orderUid: "0xuid",
+      order: { kind: "sell", sellAmount: 1n, buyAmount: 1n, feeAmount: 0n },
+      orderBookApi: { sendOrder } as never,
+      blockTimestamp: NOW,
+      dryRun: false,
+      metricLabels: ["8453", "0xhandler", "0xowner", "0xid"],
+      chainId: 8453 as never,
+      blockNumber: 1,
+      ownerNumber: 1,
+      orderNumber: 1,
+    });
+
+  // Backoff tiers describe "this order keeps failing the same way". A run of
+  // balance failures must not push an unrelated quote failure straight to the
+  // top tier.
+  it("restarts the count when the API error changes", async () => {
+    const conditionalOrder = {
+      id: "0xid",
+      consecutiveApiFailures: 5,
+      lastApiError: "InsufficientBalance",
+    } as ConditionalOrder;
+
+    const result = await postWith(
+      conditionalOrder,
+      rejectsWith("QuoteNotFound")
+    );
+
+    expect(result).toMatchObject({ result: PollResultCode.TRY_NEXT_BLOCK });
+    expect(conditionalOrder.consecutiveApiFailures).toBe(1);
+  });
+
+  it("keeps counting while the same API error repeats", async () => {
+    const conditionalOrder = {
+      id: "0xid",
+      consecutiveApiFailures: 2,
+      lastApiError: "QuoteNotFound",
+    } as ConditionalOrder;
+
+    const result = await postWith(
+      conditionalOrder,
+      rejectsWith("QuoteNotFound")
+    );
+
+    expect(result).toMatchObject({ result: PollResultCode.TRY_AT_EPOCH });
+    expect(conditionalOrder.consecutiveApiFailures).toBe(3);
   });
 });

--- a/src/domain/polling/polling.spec.ts
+++ b/src/domain/polling/polling.spec.ts
@@ -3,7 +3,9 @@ import {
   escalatingRetryDelay,
   handleOrderBookError,
   postDiscreteOrder,
+  checkForAndPlaceOrder,
 } from ".";
+import { ConditionalOrder, OrderStatus, Registry } from "../../types";
 import { WATCHDOG_TIMEOUT_DEFAULT_SECS } from "../../services/chain";
 import { initLogging } from "../../utils";
 import { PollResultCode } from "@cowprotocol/sdk-composable";
@@ -106,5 +108,71 @@ describe("postDiscreteOrder", () => {
 
     expect(result).toMatchObject({ result: PollResultCode.UNEXPECTED_ERROR });
     expect((result as { reason: string }).reason).toContain("socket hang up");
+  });
+});
+
+describe("checkForAndPlaceOrder chunked writes", () => {
+  const NOW_EPOCH = 1_784_857_003;
+  const expiredUid = (i: number) =>
+    "0x" +
+    i.toString(16).padStart(64, "0") +
+    "bb".repeat(20) +
+    (NOW_EPOCH - 600).toString(16).padStart(8, "0");
+
+  // More than CHUNK_SIZE (50) so the chunked write at updatedCount === 51 fires
+  const ORDER_COUNT = 60;
+
+  const buildRegistry = (persisted: string[]) => {
+    const orders = Array.from({ length: ORDER_COUNT }, (_, i) => ({
+      id: `0x${i}`,
+      tx: "0xtx",
+      params: { handler: "0xhandler", salt: "0xsalt", staticInput: "0x" },
+      proof: null,
+      orders: new Map([[expiredUid(i), OrderStatus.SUBMITTED]]),
+      composableCow: "0xccow",
+    })) as unknown as ConditionalOrder[];
+
+    const batch: { put: jest.Mock; del: jest.Mock; write: jest.Mock } = {
+      put: jest.fn((key: string, value: string) => {
+        if (String(key) === "CONDITIONAL_ORDER_REGISTRY_8453") {
+          persisted.push(value);
+        }
+        return batch;
+      }),
+      del: jest.fn(() => batch),
+      write: jest.fn(async () => undefined),
+    };
+
+    return new Registry(
+      new Map([["0xowner", new Set(orders)]]) as never,
+      { getDB: () => ({ batch: () => batch }) } as never,
+      "8453",
+      null,
+      { number: 1, timestamp: NOW_EPOCH, hash: "0x0" }
+    );
+  };
+
+  it("excludes expired uids from the first persisted registry", async () => {
+    const persisted: string[] = [];
+    const registry = buildRegistry(persisted);
+
+    const context = {
+      chainId: 8453,
+      registry,
+      filterPolicy: undefined,
+      provider: { _isProvider: true },
+      orderBookApi: {},
+      dryRun: true,
+      contract: {},
+      multicall: {},
+    } as never;
+
+    await checkForAndPlaceOrder(context, {
+      number: 1,
+      timestamp: NOW_EPOCH,
+    } as never).catch(() => undefined);
+
+    expect(persisted.length).toBeGreaterThan(1);
+    expect(persisted[0]).not.toContain(expiredUid(0));
   });
 });

--- a/src/services/chain.spec.ts
+++ b/src/services/chain.spec.ts
@@ -1,6 +1,8 @@
 import { providers } from "ethers";
 import {
   ChainSync,
+  RPC_TIMEOUT_MS,
+  WARM_UP_RPC_TIMEOUT_MS,
   getEventPollingRange,
   isReorg,
   watchdogSyncState,
@@ -102,5 +104,14 @@ describe("watchdogSyncState", () => {
     expect(watchdogSyncState(WATCHDOG_TIMEOUT - 1, WATCHDOG_TIMEOUT)).toBe(
       ChainSync.IN_SYNC
     );
+  });
+});
+
+describe("warm-up RPC bounds", () => {
+  it("allows a warm-up call far longer than a block-path call", () => {
+    // Warm-up pages over thousands of blocks with no watchdog running, so a
+    // slow backfill must be able to finish. The block path is serialised
+    // behind a watchdog and has to fail fast instead.
+    expect(WARM_UP_RPC_TIMEOUT_MS).toBeGreaterThan(RPC_TIMEOUT_MS);
   });
 });

--- a/src/services/chain.spec.ts
+++ b/src/services/chain.spec.ts
@@ -1,5 +1,10 @@
 import { providers } from "ethers";
-import { getEventPollingRange, isReorg } from "./chain";
+import {
+  ChainSync,
+  getEventPollingRange,
+  isReorg,
+  watchdogSyncState,
+} from "./chain";
 
 const block = (
   number: number,
@@ -82,4 +87,20 @@ describe("getEventPollingRange", () => {
       );
     }
   );
+});
+
+describe("watchdogSyncState", () => {
+  const WATCHDOG_TIMEOUT = 300;
+
+  it("reports UNKNOWN once the timeout has elapsed without a processed block", () => {
+    expect(watchdogSyncState(WATCHDOG_TIMEOUT, WATCHDOG_TIMEOUT)).toBe(
+      ChainSync.UNKNOWN
+    );
+  });
+
+  it("recovers to IN_SYNC once blocks are being processed again", () => {
+    expect(watchdogSyncState(WATCHDOG_TIMEOUT - 1, WATCHDOG_TIMEOUT)).toBe(
+      ChainSync.IN_SYNC
+    );
+  });
 });

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -32,8 +32,23 @@ import {
 const WATCHDOG_FREQUENCY_SECS = 5; // 5 seconds
 export const WATCHDOG_TIMEOUT_DEFAULT_SECS = 60;
 
-/** Upper bound on a single RPC call made from the block processing path */
-const RPC_TIMEOUT_MS = 30_000;
+/**
+ * Upper bound on a single RPC call made from the block processing path, where
+ * work is serialised behind the watchdog and must fail fast.
+ */
+export const RPC_TIMEOUT_MS = 30_000;
+
+/**
+ * Upper bound on a single warm-up RPC call.
+ *
+ * Deliberately far larger than `RPC_TIMEOUT_MS`: warm-up pages over `pageSize`
+ * blocks at a time and a cold-start backfill can legitimately take minutes per
+ * page on a rate limited RPC. Retrying would not help there - every attempt
+ * would hit the same deadline - and the failure exits the whole process. This
+ * only exists so a genuinely hung socket eventually errors instead of hanging
+ * warm-up forever.
+ */
+export const WARM_UP_RPC_TIMEOUT_MS = 180_000;
 
 /** Warm-up RPC calls are retried rather than crashing the whole run */
 const WARM_UP_RPC_ATTEMPTS = 5;
@@ -203,15 +218,18 @@ export class ChainContext {
     // with it. So bound each RPC call and retry transient failures with
     // backoff, isolating a flaky RPC to the chain it belongs to.
     const rpc = <T>(operation: () => Promise<T>, description: string) =>
-      withRetry(() => withTimeout(operation(), RPC_TIMEOUT_MS, description), {
-        attempts: WARM_UP_RPC_ATTEMPTS,
-        baseDelayMs: WARM_UP_RPC_BASE_DELAY_MS,
-        onRetry: (attempt, error, delayMs) =>
-          log.warn(
-            `${description} failed (attempt ${attempt}/${WARM_UP_RPC_ATTEMPTS}), retrying in ${delayMs}ms`,
-            error
-          ),
-      });
+      withRetry(
+        () => withTimeout(operation(), WARM_UP_RPC_TIMEOUT_MS, description),
+        {
+          attempts: WARM_UP_RPC_ATTEMPTS,
+          baseDelayMs: WARM_UP_RPC_BASE_DELAY_MS,
+          onRetry: (attempt, error, delayMs) =>
+            log.warn(
+              `${description} failed (attempt ${attempt}/${WARM_UP_RPC_ATTEMPTS}), retrying in ${delayMs}ms`,
+              error
+            ),
+        }
+      );
     let { lastProcessedBlock } = this.registry;
     const { pageSize } = this;
 
@@ -426,9 +444,10 @@ export class ChainContext {
 
           // Bound the RPC call here rather than inside `pollContractForEvents`
           // - block processing is serialised, so a hung `getLogs` stalls every
-          // block queued behind it. Warm-up shares that helper but pages over
-          // thousands of blocks with no watchdog running, so it must stay
-          // unbounded or a slow backfill would exit the process.
+          // block queued behind it and must fail fast. Warm-up shares that
+          // helper but bounds it far more loosely (`WARM_UP_RPC_TIMEOUT_MS`),
+          // because paging over thousands of blocks is legitimately slow and
+          // there is no watchdog to satisfy.
           const events = await withTimeout(
             pollContractForEvents(fromBlock, toBlock, this),
             RPC_TIMEOUT_MS,

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -25,14 +25,19 @@ import {
   isRunningInKubernetesPod,
   LoggerWithMethods,
   metrics,
+  withRetry,
   withTimeout,
 } from "../utils";
 
 const WATCHDOG_FREQUENCY_SECS = 5; // 5 seconds
-const WATCHDOG_TIMEOUT_DEFAULT_SECS = 30;
+export const WATCHDOG_TIMEOUT_DEFAULT_SECS = 60;
 
 /** Upper bound on a single RPC call made from the block processing path */
 const RPC_TIMEOUT_MS = 30_000;
+
+/** Warm-up RPC calls are retried rather than crashing the whole run */
+const WARM_UP_RPC_ATTEMPTS = 5;
+const WARM_UP_RPC_BASE_DELAY_MS = 1_000;
 
 const MULTICALL3 = "0xcA11bde05977b3631167028862bE2a173976CA11";
 const PAGE_SIZE_DEFAULT = 5000;
@@ -192,6 +197,21 @@ export class ChainContext {
   public async warmUp(oneShot?: boolean) {
     const { provider, chainId, processEveryNumBlocks } = this;
     const log = getLogger({ name: "warmUp", chainId });
+
+    // Warm-up runs before the watchdog starts, and any error escaping here
+    // reaches `run()` and exits the process - taking down every other chain
+    // with it. So bound each RPC call and retry transient failures with
+    // backoff, isolating a flaky RPC to the chain it belongs to.
+    const rpc = <T>(operation: () => Promise<T>, description: string) =>
+      withRetry(() => withTimeout(operation(), RPC_TIMEOUT_MS, description), {
+        attempts: WARM_UP_RPC_ATTEMPTS,
+        baseDelayMs: WARM_UP_RPC_BASE_DELAY_MS,
+        onRetry: (attempt, error, delayMs) =>
+          log.warn(
+            `${description} failed (attempt ${attempt}/${WARM_UP_RPC_ATTEMPTS}), retrying in ${delayMs}ms`,
+            error
+          ),
+      });
     let { lastProcessedBlock } = this.registry;
     const { pageSize } = this;
 
@@ -208,7 +228,10 @@ export class ChainContext {
       ? lastProcessedBlock.number + 1
       : this.deploymentBlock;
 
-    let currentBlock = await provider.getBlock("latest");
+    let currentBlock = await rpc(
+      () => provider.getBlock("latest"),
+      "getBlock latest"
+    );
     metrics.blockHeightLatest
       .labels(chainId.toString())
       .set(currentBlock.number);
@@ -220,7 +243,10 @@ export class ChainContext {
         toBlock = !pageSize ? "latest" : fromBlock + (pageSize - 1);
         if (typeof toBlock === "number" && toBlock > currentBlock.number) {
           // refresh the current block
-          currentBlock = await provider.getBlock("latest");
+          currentBlock = await rpc(
+            () => provider.getBlock("latest"),
+            "getBlock latest"
+          );
           metrics.blockHeightLatest
             .labels(chainId.toString())
             .set(currentBlock.number);
@@ -259,7 +285,10 @@ export class ChainContext {
           `Processing events from block ${fromBlock} to block ${toBlock}`
         );
 
-        const events = await pollContractForEvents(fromBlock, toBlock, this);
+        const events = await rpc(
+          () => pollContractForEvents(fromBlock, toBlock, this),
+          `getLogs ${fromBlock}..${toBlock}`
+        );
 
         if (events.length > 0) {
           log.debug(`Found ${events.length} events`);
@@ -295,7 +324,10 @@ export class ChainContext {
         // Persist "toBlock" as the last block (even if there's no events, we are caught up until this block)
         lastProcessedBlock = await persistLastProcessedBlock({
           context: this,
-          block: await provider.getBlock(toBlock),
+          block: await rpc(
+            () => provider.getBlock(toBlock),
+            `getBlock ${toBlock}`
+          ),
           log,
         });
 
@@ -307,7 +339,10 @@ export class ChainContext {
 
       // It may have taken some time to process the blocks, so refresh the current block number
       // and check if we are in sync
-      currentBlock = await provider.getBlock("latest");
+      currentBlock = await rpc(
+        () => provider.getBlock("latest"),
+        "getBlock latest"
+      );
       metrics.blockHeightLatest
         .labels(chainId.toString())
         .set(currentBlock.number);
@@ -389,7 +424,16 @@ export class ChainContext {
               .set(Math.max(lastBlockReceived.number - block.number + 1, 1));
           }
 
-          const events = await pollContractForEvents(fromBlock, toBlock, this);
+          // Bound the RPC call here rather than inside `pollContractForEvents`
+          // - block processing is serialised, so a hung `getLogs` stalls every
+          // block queued behind it. Warm-up shares that helper but pages over
+          // thousands of blocks with no watchdog running, so it must stay
+          // unbounded or a slow backfill would exit the process.
+          const events = await withTimeout(
+            pollContractForEvents(fromBlock, toBlock, this),
+            RPC_TIMEOUT_MS,
+            `getLogs ${fromBlock}..${toBlock}`
+          );
 
           await processBlockAndPersist({
             context: this,
@@ -631,17 +675,11 @@ async function pollContractForEvents(
   const eventName = "ConditionalOrderCreated(address,(address,bytes32,bytes))";
   const topic = ethers.utils.id(eventName);
 
-  // Bound the RPC call - block processing is serialised, so a hung `getLogs`
-  // stalls every block queued behind it.
-  const logs = await withTimeout(
-    provider.getLogs({
-      fromBlock,
-      toBlock,
-      topics: [topic],
-    }),
-    RPC_TIMEOUT_MS,
-    `getLogs ${fromBlock}..${toBlock}`
-  );
+  const logs = await provider.getLogs({
+    fromBlock,
+    toBlock,
+    topics: [topic],
+  });
 
   return logs.reduce<ConditionalOrderCreatedEvent[]>((acc, event) => {
     try {

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -505,8 +505,15 @@ export class ChainContext {
         continue;
       }
 
-      // We need to handle our own exit here as the process is not running in a kubernetes pod
-      await registry.storage.close();
+      // We need to handle our own exit here as the process is not running in a
+      // kubernetes pod. Exit even if closing the database fails: warm-up is
+      // retried as a unit, so letting an error escape here would re-enter
+      // `subscribeToNewBlocks` and attach a second `block` listener.
+      try {
+        await registry.storage.close();
+      } catch (error) {
+        log.error("Error closing the database while shutting down", error);
+      }
       process.exit(1);
     }
   }
@@ -520,6 +527,18 @@ export class ChainContext {
       lastProcessedBlock: this.registry.lastProcessedBlock,
       isHealthy: this.isHealthy(),
     };
+  }
+
+  /**
+   * Flag the chain as no longer in sync.
+   *
+   * Called when warm-up has been abandoned: nothing is watching this chain any
+   * more, so `/health` must stop reporting it healthy even though the process
+   * stays up for the chains that are still working.
+   */
+  public markUnhealthy() {
+    this.sync = ChainSync.UNKNOWN;
+    metrics.syncStatus.labels(this.chainId.toString()).set(0);
   }
 
   /** Determine if the specific chain is healthy */

--- a/src/services/chain.ts
+++ b/src/services/chain.ts
@@ -25,10 +25,14 @@ import {
   isRunningInKubernetesPod,
   LoggerWithMethods,
   metrics,
+  withTimeout,
 } from "../utils";
 
 const WATCHDOG_FREQUENCY_SECS = 5; // 5 seconds
 const WATCHDOG_TIMEOUT_DEFAULT_SECS = 30;
+
+/** Upper bound on a single RPC call made from the block processing path */
+const RPC_TIMEOUT_MS = 30_000;
 
 const MULTICALL3 = "0xcA11bde05977b3631167028862bE2a173976CA11";
 const PAGE_SIZE_DEFAULT = 5000;
@@ -45,7 +49,7 @@ function configureSdkAdapters(provider: providers.Provider): EthersV5Adapter {
   return sdkAdapter;
 }
 
-enum ChainSync {
+export enum ChainSync {
   /** The chain is currently in the warm-up phase, synchronising from contract genesis or lastBlockProcessed */
   SYNCING = "SYNCING",
   /** The chain is in sync with the latest block */
@@ -415,19 +419,32 @@ export class ChainContext {
 
       // If we haven't received a block within `watchdogTimeout` seconds, either signal
       // an error or exit if not running in a kubernetes pod
-      if (timeElapsed >= watchdogTimeout) {
-        log.error(
-          `Chain watcher last processed a block ${timeElapsed}s ago (${watchdogTimeout}s timeout configured). Check the RPC.`
-        );
-        if (isRunningInKubernetesPod()) {
-          this.sync = ChainSync.UNKNOWN;
-          continue;
+      const sync = watchdogSyncState(timeElapsed, watchdogTimeout);
+      if (sync === ChainSync.IN_SYNC) {
+        // Blocks are flowing again (or never stopped). Clear any previous
+        // `UNKNOWN` so `/health` reports healthy without needing a restart -
+        // otherwise a single transient stall permanently fails the liveness
+        // probe and the pod is killed even though it has recovered.
+        if (this.sync !== ChainSync.IN_SYNC) {
+          log.info(
+            `Chain watcher recovered, last block processed ${timeElapsed}s ago`
+          );
+          this.sync = sync;
         }
-
-        // We need to handle our own exit here as the process is not running in a kubernetes pod
-        await registry.storage.close();
-        process.exit(1);
+        continue;
       }
+
+      log.error(
+        `Chain watcher last processed a block ${timeElapsed}s ago (${watchdogTimeout}s timeout configured). Check the RPC.`
+      );
+      if (isRunningInKubernetesPod()) {
+        this.sync = sync;
+        continue;
+      }
+
+      // We need to handle our own exit here as the process is not running in a kubernetes pod
+      await registry.storage.close();
+      process.exit(1);
     }
   }
 
@@ -614,11 +631,17 @@ async function pollContractForEvents(
   const eventName = "ConditionalOrderCreated(address,(address,bytes32,bytes))";
   const topic = ethers.utils.id(eventName);
 
-  const logs = await provider.getLogs({
-    fromBlock,
-    toBlock,
-    topics: [topic],
-  });
+  // Bound the RPC call - block processing is serialised, so a hung `getLogs`
+  // stalls every block queued behind it.
+  const logs = await withTimeout(
+    provider.getLogs({
+      fromBlock,
+      toBlock,
+      topics: [topic],
+    }),
+    RPC_TIMEOUT_MS,
+    `getLogs ${fromBlock}..${toBlock}`
+  );
 
   return logs.reduce<ConditionalOrderCreatedEvent[]>((acc, event) => {
     try {
@@ -688,6 +711,17 @@ export async function isReorg(
   return (
     (await provider.getBlock(previousBlock.number)).hash !== previousBlock.hash
   );
+}
+
+/**
+ * Determine the sync state the watchdog should report, given how long ago the
+ * last block was processed.
+ */
+export function watchdogSyncState(
+  timeElapsed: number,
+  watchdogTimeout: number
+): ChainSync {
+  return timeElapsed >= watchdogTimeout ? ChainSync.UNKNOWN : ChainSync.IN_SYNC;
 }
 
 export function getEventPollingRange(

--- a/src/types/model.spec.ts
+++ b/src/types/model.spec.ts
@@ -51,6 +51,16 @@ describe("pruneExpiredOrders", () => {
     expect(orders.has(malformed)).toBe(true);
   });
 
+  it("keeps a full-length uid whose validTo is not valid hex", () => {
+    // `parseInt` stops at the first invalid character rather than returning
+    // NaN, so a truncated parse would look long expired and be pruned
+    const malformed = "0x" + "aa".repeat(32) + "bb".repeat(20) + "6a6429az";
+    const orders = ordersWith([malformed]);
+
+    expect(pruneExpiredOrders(orders, NOW)).toBe(0);
+    expect(orders.has(malformed)).toBe(true);
+  });
+
   it("prunes only the expired entries of a mixed registry", () => {
     const live = orderUid(NOW + 600, "11");
     const orders = ordersWith([
@@ -117,7 +127,9 @@ describe("Registry.write", () => {
     return batch;
   };
 
-  it("prunes expired discrete orders before serialising", async () => {
+  // `write()` is called on every CHUNK_SIZE orders, so it must stay cheap.
+  // Pruning is a whole-registry scan and belongs to the once-per-block caller.
+  it("does not prune, leaving that to the once-per-block caller", async () => {
     const batch = fakeBatch();
     const storage = {
       getDB: () => ({ batch: () => batch }),
@@ -142,10 +154,6 @@ describe("Registry.write", () => {
 
     await registry.write();
 
-    expect([...order.orders.keys()]).toEqual([live]);
-    const serialised = batch.put.mock.calls.find((call: unknown[]) =>
-      String(call[0]).startsWith("CONDITIONAL_ORDER_REGISTRY_")
-    );
-    expect(String(serialised?.[1])).not.toContain(expired);
+    expect([...order.orders.keys()]).toEqual([expired, live]);
   });
 });

--- a/src/types/model.spec.ts
+++ b/src/types/model.spec.ts
@@ -1,0 +1,151 @@
+import {
+  ConditionalOrder,
+  OrderStatus,
+  OrderUid,
+  OrdersPerOwner,
+  Registry,
+  pruneExpiredOrders,
+} from "./model";
+import { DBService } from "../services";
+import { initLogging } from "../utils";
+
+initLogging({});
+
+/**
+ * Build a GPv2 order uid: `keccak256(orderDigest) || owner || validTo`,
+ * i.e. 32 bytes of digest, 20 bytes of owner and 4 bytes of `validTo`.
+ */
+const orderUid = (validTo: number, digestByte = "aa"): string =>
+  "0x" +
+  digestByte.repeat(32) +
+  "bb".repeat(20) +
+  validTo.toString(16).padStart(8, "0");
+
+const NOW = 1_784_857_003;
+
+describe("pruneExpiredOrders", () => {
+  const ordersWith = (uids: string[]): Map<OrderUid, OrderStatus> =>
+    new Map(uids.map((uid) => [uid, OrderStatus.SUBMITTED]));
+
+  it("removes orders whose validTo has already passed", () => {
+    const expired = orderUid(NOW - 1);
+    const orders = ordersWith([expired]);
+
+    expect(pruneExpiredOrders(orders, NOW)).toBe(1);
+    expect(orders.has(expired)).toBe(false);
+  });
+
+  it("keeps orders that are still valid", () => {
+    const live = orderUid(NOW + 1);
+    const orders = ordersWith([live]);
+
+    expect(pruneExpiredOrders(orders, NOW)).toBe(0);
+    expect(orders.has(live)).toBe(true);
+  });
+
+  it("keeps uids it cannot parse rather than dropping unknown state", () => {
+    const malformed = "0xdeadbeef";
+    const orders = ordersWith([malformed]);
+
+    expect(pruneExpiredOrders(orders, NOW)).toBe(0);
+    expect(orders.has(malformed)).toBe(true);
+  });
+
+  it("prunes only the expired entries of a mixed registry", () => {
+    const live = orderUid(NOW + 600, "11");
+    const orders = ordersWith([
+      orderUid(NOW - 600, "22"),
+      live,
+      orderUid(NOW - 1, "33"),
+    ]);
+
+    expect(pruneExpiredOrders(orders, NOW)).toBe(2);
+    expect([...orders.keys()]).toEqual([live]);
+  });
+});
+
+describe("Registry.prune", () => {
+  const conditionalOrder = (orders: string[]): ConditionalOrder =>
+    ({
+      id: "0x01",
+      tx: "0x02",
+      proof: null,
+      composableCow: "0x03",
+      orders: new Map(orders.map((uid) => [uid, OrderStatus.SUBMITTED])),
+    } as unknown as ConditionalOrder);
+
+  const registryWith = (owners: ConditionalOrder[][]): Registry =>
+    new Registry(
+      new Map(
+        owners.map((orders, i) => [`0xowner${i}`, new Set(orders)])
+      ) as OrdersPerOwner,
+      undefined as unknown as DBService,
+      "1",
+      null,
+      null
+    );
+
+  it("prunes expired discrete orders across every owner", () => {
+    const live = orderUid(NOW + 600, "11");
+    const registry = registryWith([
+      [conditionalOrder([orderUid(NOW - 600, "22"), live])],
+      [conditionalOrder([orderUid(NOW - 1, "33")])],
+    ]);
+
+    expect(registry.prune(NOW)).toBe(2);
+
+    const remaining = [...registry.ownerOrders.values()]
+      .flatMap((orders) => [...orders])
+      .flatMap((order) => [...order.orders.keys()]);
+    expect(remaining).toEqual([live]);
+  });
+});
+
+describe("Registry.write", () => {
+  type FakeBatch = {
+    put: jest.Mock;
+    del: jest.Mock;
+    write: jest.Mock;
+  };
+
+  const fakeBatch = (): FakeBatch => {
+    const batch: FakeBatch = {
+      put: jest.fn(() => batch),
+      del: jest.fn(() => batch),
+      write: jest.fn(async () => undefined),
+    };
+    return batch;
+  };
+
+  it("prunes expired discrete orders before serialising", async () => {
+    const batch = fakeBatch();
+    const storage = {
+      getDB: () => ({ batch: () => batch }),
+    } as unknown as DBService;
+
+    const expired = orderUid(NOW - 1, "44");
+    const live = orderUid(NOW + 600, "55");
+    const order = {
+      orders: new Map([
+        [expired, OrderStatus.SUBMITTED],
+        [live, OrderStatus.SUBMITTED],
+      ]),
+    } as unknown as ConditionalOrder;
+
+    const registry = new Registry(
+      new Map([["0xowner", new Set([order])]]) as OrdersPerOwner,
+      storage,
+      "1",
+      null,
+      { number: 1, timestamp: NOW, hash: "0x0" }
+    );
+
+    await registry.write();
+
+    expect([...order.orders.keys()]).toEqual([live]);
+    const serialised = batch.put.mock.calls.find((call: unknown[]) =>
+      String(call[0]).startsWith("CONDITIONAL_ORDER_REGISTRY_")
+    );
+    expect(String(serialised?.[1])).not.toContain(expired);
+  });
+});

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -129,26 +129,28 @@ export function pruneExpiredOrders(
   return pruned;
 }
 
-/** `"0x"` + 32 byte order digest + 20 byte owner + 4 byte `validTo` */
-const ORDER_UID_HEX_LENGTH = 2 + 2 * (32 + 20 + 4);
+/** 32 byte order digest + 20 byte owner + 4 byte `validTo`, as hex characters */
+const ORDER_UID_HEX_CHARS = 2 * (32 + 20 + 4);
 const VALID_TO_HEX_LENGTH = 2 * 4;
+
+/** A complete GPv2 order uid: `0x` followed by 112 hex characters */
+const ORDER_UID_PATTERN = new RegExp(`^0x[0-9a-fA-F]{${ORDER_UID_HEX_CHARS}}$`);
 
 /**
  * Read the `validTo` encoded in the trailing 4 bytes of a GPv2 order uid.
  * Returns `undefined` for anything that isn't a well formed uid, so unknown
  * entries are retained rather than silently discarded.
+ *
+ * The uid must be validated in full before parsing: `parseInt` stops at the
+ * first invalid character instead of returning `NaN`, so a corrupt uid would
+ * otherwise yield a truncated `validTo` that looks long expired and be pruned.
  */
 function getOrderUidValidTo(orderUid: OrderUid): number | undefined {
-  if (
-    typeof orderUid !== "string" ||
-    orderUid.length !== ORDER_UID_HEX_LENGTH
-  ) {
+  if (typeof orderUid !== "string" || !ORDER_UID_PATTERN.test(orderUid)) {
     return undefined;
   }
 
-  const validTo = Number.parseInt(orderUid.slice(-VALID_TO_HEX_LENGTH), 16);
-
-  return Number.isNaN(validTo) ? undefined : validTo;
+  return Number.parseInt(orderUid.slice(-VALID_TO_HEX_LENGTH), 16);
 }
 
 export interface RegistryBlock {
@@ -282,18 +284,6 @@ export class Registry {
   }
 
   public async write(): Promise<void> {
-    // Evict discrete orders that can no longer be placed before serialising.
-    // `orders` is otherwise append-only and dominates the persisted payload -
-    // left unbounded it grows into tens of megabytes, and every block pays for
-    // it twice, once to `JSON.stringify` and once to write to LevelDB.
-    const nowEpoch = this.lastProcessedBlock?.timestamp;
-    if (nowEpoch !== undefined) {
-      const pruned = this.prune(nowEpoch);
-      if (pruned > 0) {
-        this.logger.debug(`Pruned ${pruned} expired discrete orders`);
-      }
-    }
-
     const batch = this.storage
       .getDB()
       .batch()

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -82,6 +82,15 @@ export type ConditionalOrder = {
   composableCow: string;
 
   /**
+   * How many times in a row placing this order has been rejected by the API.
+   *
+   * Drives an escalating backoff so an order that is permanently invalid (bad
+   * EIP-1271 signature, unknown appData pre-image) stops being retried on every
+   * block. Reset to `0` as soon as an order is accepted.
+   */
+  consecutiveApiFailures?: number;
+
+  /**
    * The result of the last poll
    */
   pollResult?: {
@@ -91,13 +100,64 @@ export type ConditionalOrder = {
   };
 };
 
+/**
+ * Drop discrete orders that can no longer be placed from the dedup map.
+ *
+ * `orders` only exists to avoid re-posting an `orderUid` we have already
+ * submitted. Once an order's `validTo` has passed it can never be posted
+ * again, so retaining it serves no purpose - and left unbounded this map is
+ * what makes the persisted registry grow into the tens of megabytes.
+ *
+ * @returns the number of entries removed
+ */
+export function pruneExpiredOrders(
+  orders: Map<OrderUid, OrderStatus>,
+  nowEpoch: number
+): number {
+  let pruned = 0;
+
+  // Deleting while iterating a `Map` is well defined - entries already visited
+  // are unaffected and the deleted key is simply skipped.
+  for (const orderUid of orders.keys()) {
+    const validTo = getOrderUidValidTo(orderUid);
+    if (validTo !== undefined && validTo < nowEpoch) {
+      orders.delete(orderUid);
+      pruned++;
+    }
+  }
+
+  return pruned;
+}
+
+/** `"0x"` + 32 byte order digest + 20 byte owner + 4 byte `validTo` */
+const ORDER_UID_HEX_LENGTH = 2 + 2 * (32 + 20 + 4);
+const VALID_TO_HEX_LENGTH = 2 * 4;
+
+/**
+ * Read the `validTo` encoded in the trailing 4 bytes of a GPv2 order uid.
+ * Returns `undefined` for anything that isn't a well formed uid, so unknown
+ * entries are retained rather than silently discarded.
+ */
+function getOrderUidValidTo(orderUid: OrderUid): number | undefined {
+  if (
+    typeof orderUid !== "string" ||
+    orderUid.length !== ORDER_UID_HEX_LENGTH
+  ) {
+    return undefined;
+  }
+
+  const validTo = Number.parseInt(orderUid.slice(-VALID_TO_HEX_LENGTH), 16);
+
+  return Number.isNaN(validTo) ? undefined : validTo;
+}
+
 export interface RegistryBlock {
   number: number;
   timestamp: number;
   hash: string;
 }
 
-type OrdersPerOwner = Map<Owner, Set<ConditionalOrder>>;
+export type OrdersPerOwner = Map<Owner, Set<ConditionalOrder>>;
 
 /**
  * Models the state between executions.
@@ -205,9 +265,35 @@ export class Registry {
   }
 
   /**
-   * Write the registry to storage.
+   * Drop discrete orders that can no longer be placed, across every owner.
+   * @param nowEpoch the chain timestamp to consider "now"
+   * @returns the number of entries removed
    */
+  public prune(nowEpoch: number): number {
+    let pruned = 0;
+
+    for (const conditionalOrders of this.ownerOrders.values()) {
+      for (const conditionalOrder of conditionalOrders) {
+        pruned += pruneExpiredOrders(conditionalOrder.orders, nowEpoch);
+      }
+    }
+
+    return pruned;
+  }
+
   public async write(): Promise<void> {
+    // Evict discrete orders that can no longer be placed before serialising.
+    // `orders` is otherwise append-only and dominates the persisted payload -
+    // left unbounded it grows into tens of megabytes, and every block pays for
+    // it twice, once to `JSON.stringify` and once to write to LevelDB.
+    const nowEpoch = this.lastProcessedBlock?.timestamp;
+    if (nowEpoch !== undefined) {
+      const pruned = this.prune(nowEpoch);
+      if (pruned > 0) {
+        this.logger.debug(`Pruned ${pruned} expired discrete orders`);
+      }
+    }
+
     const batch = this.storage
       .getDB()
       .batch()

--- a/src/types/model.ts
+++ b/src/types/model.ts
@@ -82,6 +82,14 @@ export type ConditionalOrder = {
   composableCow: string;
 
   /**
+   * Chain timestamp at which this conditional order was first seen.
+   *
+   * Backfilled on first poll for orders persisted before this field existed,
+   * so the clock starts at that point rather than being unknown forever.
+   */
+  createdAtEpoch?: number;
+
+  /**
    * How many times in a row placing this order has been rejected by the API.
    *
    * Drives an escalating backoff so an order that is permanently invalid (bad
@@ -89,6 +97,14 @@ export type ConditionalOrder = {
    * block. Reset to `0` as soon as an order is accepted.
    */
   consecutiveApiFailures?: number;
+
+  /**
+   * The API error type behind `consecutiveApiFailures`.
+   *
+   * The backoff tiers mean "this order keeps failing the same way", so the
+   * count restarts when the API starts rejecting it for a different reason.
+   */
+  lastApiError?: string;
 
   /**
    * The result of the last poll

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,5 +2,6 @@ export * from "./context";
 export * from "./contracts";
 export * from "./misc";
 export * from "./timeout";
+export * from "./retry";
 export * from "./logging";
 export * as metrics from "./metrics";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from "./context";
 export * from "./contracts";
 export * from "./misc";
+export * from "./timeout";
 export * from "./logging";
 export * as metrics from "./metrics";

--- a/src/utils/retry.spec.ts
+++ b/src/utils/retry.spec.ts
@@ -1,0 +1,54 @@
+import { withRetry } from "./retry";
+
+const opts = (onRetry?: (attempt: number, e: unknown, ms: number) => void) => ({
+  attempts: 4,
+  baseDelayMs: 1,
+  onRetry,
+});
+
+describe("withRetry", () => {
+  it("returns the result without retrying when the operation succeeds", async () => {
+    const operation = jest.fn(async () => "ok");
+
+    await expect(withRetry(operation, opts())).resolves.toBe("ok");
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries until the operation succeeds", async () => {
+    let calls = 0;
+    const operation = jest.fn(async () => {
+      calls++;
+      if (calls < 3) throw new Error("rpc flake");
+      return "ok";
+    });
+
+    await expect(withRetry(operation, opts())).resolves.toBe("ok");
+    expect(calls).toBe(3);
+  });
+
+  it("rethrows the final error once attempts are exhausted", async () => {
+    const operation = jest.fn(async () => {
+      throw new Error("rpc down");
+    });
+
+    await expect(withRetry(operation, opts())).rejects.toThrow("rpc down");
+    expect(operation).toHaveBeenCalledTimes(4);
+  });
+
+  it("backs off exponentially between attempts", async () => {
+    const delays: number[] = [];
+    const operation = async () => {
+      throw new Error("rpc down");
+    };
+
+    await expect(
+      withRetry(
+        operation,
+        opts((_a, _e, ms) => delays.push(ms))
+      )
+    ).rejects.toThrow("rpc down");
+
+    // 3 retries after the initial attempt, doubling each time
+    expect(delays).toEqual([1, 2, 4]);
+  });
+});

--- a/src/utils/retry.spec.ts
+++ b/src/utils/retry.spec.ts
@@ -51,4 +51,22 @@ describe("withRetry", () => {
     // 3 retries after the initial attempt, doubling each time
     expect(delays).toEqual([1, 2, 4]);
   });
+
+  it("caps the backoff so a long retry loop stays bounded", async () => {
+    const delays: number[] = [];
+    const operation = async () => {
+      throw new Error("rpc down");
+    };
+
+    await expect(
+      withRetry(operation, {
+        attempts: 5,
+        baseDelayMs: 10,
+        maxDelayMs: 25,
+        onRetry: (_a, _e, ms) => delays.push(ms),
+      })
+    ).rejects.toThrow("rpc down");
+
+    expect(delays).toEqual([10, 20, 25, 25]);
+  });
 });

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -1,0 +1,39 @@
+export interface RetryOptions {
+  /** Total attempts, including the first one */
+  attempts: number;
+  /** Delay before the first retry; doubles on each subsequent retry */
+  baseDelayMs: number;
+  /** Called before sleeping, so the caller can log the upcoming retry */
+  onRetry?: (attempt: number, error: unknown, delayMs: number) => void;
+}
+
+/**
+ * Retry an operation with exponential backoff, rethrowing the final error if
+ * every attempt fails.
+ */
+export async function withRetry<T>(
+  operation: () => Promise<T>,
+  options: RetryOptions
+): Promise<T> {
+  const { attempts, baseDelayMs, onRetry } = options;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt === attempts) {
+        break;
+      }
+
+      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      onRetry?.(attempt, error, delayMs);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+
+  throw lastError;
+}

--- a/src/utils/retry.ts
+++ b/src/utils/retry.ts
@@ -3,6 +3,8 @@ export interface RetryOptions {
   attempts: number;
   /** Delay before the first retry; doubles on each subsequent retry */
   baseDelayMs: number;
+  /** Ceiling on the doubling delay, keeping a long retry loop bounded */
+  maxDelayMs?: number;
   /** Called before sleeping, so the caller can log the upcoming retry */
   onRetry?: (attempt: number, error: unknown, delayMs: number) => void;
 }
@@ -15,7 +17,7 @@ export async function withRetry<T>(
   operation: () => Promise<T>,
   options: RetryOptions
 ): Promise<T> {
-  const { attempts, baseDelayMs, onRetry } = options;
+  const { attempts, baseDelayMs, maxDelayMs, onRetry } = options;
 
   let lastError: unknown;
 
@@ -29,7 +31,10 @@ export async function withRetry<T>(
         break;
       }
 
-      const delayMs = baseDelayMs * 2 ** (attempt - 1);
+      const delayMs = Math.min(
+        baseDelayMs * 2 ** (attempt - 1),
+        maxDelayMs ?? Infinity
+      );
       onRetry?.(attempt, error, delayMs);
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }

--- a/src/utils/timeout.spec.ts
+++ b/src/utils/timeout.spec.ts
@@ -1,0 +1,42 @@
+import { TimeoutError, withTimeout } from "./timeout";
+
+describe("withTimeout", () => {
+  it("resolves with the value when the operation completes in time", async () => {
+    await expect(
+      withTimeout(Promise.resolve("ok"), 50, "post order")
+    ).resolves.toBe("ok");
+  });
+
+  it("propagates the original rejection rather than masking it", async () => {
+    await expect(
+      withTimeout(Promise.reject(new Error("api down")), 50, "post order")
+    ).rejects.toThrow("api down");
+  });
+
+  it("rejects with a TimeoutError when the operation hangs", async () => {
+    await expect(
+      withTimeout(new Promise(() => undefined), 10, "post order")
+    ).rejects.toThrow(TimeoutError);
+  });
+
+  it("names the operation in the timeout message", async () => {
+    await expect(
+      withTimeout(new Promise(() => undefined), 10, "post order")
+    ).rejects.toThrow("post order timed out after 10ms");
+  });
+
+  it("clears its timer instead of holding the event loop open", async () => {
+    // `getActiveResourcesInfo` exists from Node 17 but isn't in @types/node 18
+    const nodeProcess = process as unknown as {
+      getActiveResourcesInfo(): string[];
+    };
+    const pendingTimers = () =>
+      nodeProcess.getActiveResourcesInfo().filter((r) => r === "Timeout")
+        .length;
+
+    const before = pendingTimers();
+    await withTimeout(Promise.resolve("ok"), 60_000, "post order");
+
+    expect(pendingTimers()).toBe(before);
+  });
+});

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -1,0 +1,34 @@
+/** Thrown when an operation wrapped in `withTimeout` does not settle in time */
+export class TimeoutError extends Error {
+  constructor(operation: string, timeoutMs: number) {
+    super(`${operation} timed out after ${timeoutMs}ms`);
+    this.name = "TimeoutError";
+  }
+}
+
+/**
+ * Bound how long an operation may take.
+ *
+ * Neither the orderbook SDK nor the ethers providers apply a request timeout,
+ * so a hung socket blocks for however long the OS takes to give up on the TCP
+ * connection - minutes. Block processing is serialised, so a single wedged
+ * request stalls the whole chain watcher behind it.
+ */
+export function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new TimeoutError(operation, timeoutMs)),
+      timeoutMs
+    );
+  });
+
+  // `finally` clears the timer on both paths, so a fast operation doesn't
+  // leave a pending timer holding the event loop open.
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}

--- a/src/utils/timeout.ts
+++ b/src/utils/timeout.ts
@@ -8,11 +8,6 @@ export class TimeoutError extends Error {
 
 /**
  * Bound how long an operation may take.
- *
- * Neither the orderbook SDK nor the ethers providers apply a request timeout,
- * so a hung socket blocks for however long the OS takes to give up on the TCP
- * connection - minutes. Block processing is serialised, so a single wedged
- * request stalls the whole chain watcher behind it.
  */
 export function withTimeout<T>(
   promise: Promise<T>,


### PR DESCRIPTION
## Summary

Fixes a ~20 minute restart loop on `base-watch-tower-develop` (~160 container restarts observed over ~34h). The pod was not OOM-killed — it was killed by the liveness probe:

1. Each block pass took ~40s (~22s posting orders, ~18s persisting a 27.5 MB registry) while only ~40s of chain time elapsed, so the watcher sat permanently ~300s behind the head.
2. Any pass that overran tripped the watchdog, which set `sync = UNKNOWN`.
3. Nothing ever set it back — both `IN_SYNC` assignments lived inside `warmUp()` — so `/health` returned 503 forever and the probe killed the pod, even though the watcher recovered within ~20-30s.

## Changes

### 1. Registry pruning — the main performance fix

`ConditionalOrder.orders` is an append-only `Map<OrderUid, OrderStatus>` used purely to dedup posts. Nothing ever removed entries and `FILLED` was never set, so it had grown to **27.5 MB for 65 orders** (~220k stale entries), re-serialised and rewritten on every block.

`pruneExpiredOrders()` decodes `validTo` from the trailing 4 bytes of the GPv2 order uid (`digest(32) || owner(20) || validTo(4)`) and drops entries that can never be posted again. Uids are validated in full against `^0x[0-9a-fA-F]{112}$` before parsing — `parseInt` stops at the first invalid character rather than returning `NaN`, so length-only validation would silently prune corrupt entries.

Pruning runs **once per block** at the start of `checkForAndPlaceOrder`, not inside `write()` — `write()` is also called every `CHUNK_SIZE` (50) orders, and a whole-registry scan there would repeat dozens of times per block. Running it before the loop also means the first post-deploy chunked write no longer serialises the full expired registry.

This removes the ~18s write and the memory sawtooth (`heapUsed` 70 → 183 MB per cycle was the 27.5 MB stringify).

### 2. Watchdog recovery

`watchdogSyncState()` returns `IN_SYNC` when `timeElapsed < watchdogTimeout`, and the watchdog loop now assigns it, logging `Chain watcher recovered`. A transient stall no longer permanently fails the liveness probe. Non-Kubernetes exit behaviour is unchanged.

**`WATCHDOG_TIMEOUT_DEFAULT_SECS` raised 30 → 60.** This doubles how long a stalled chain goes undetected for deployments using the default, and is required so `ORDER_BOOK_API_TIMEOUT_MS` can sit below it.

### 3. Retry policy for API rejections

`escalatingRetryDelay()`: attempts 1–2 retry next block, then 1 min → 10 min → 1 hr. Tracked per order via `consecutiveApiFailures`, **scoped by `lastApiError`** so a run of one error type doesn't push an unrelated error straight to the top tier. Reset on acceptance, including `DUPLICATED_ORDER`.

**`InvalidEip1271Signature` is deliberately exempt.** It is the expected response while a presign transaction is unexecuted, which for a Safe can legitimately last days. Those orders keep polling **every block** so they are placed the moment the presign lands. They are only dropped once the conditional order is older than `PRESIGN_MAX_AGE_SECS` (5 days), at which point the presign is assumed never to be coming. `createdAtEpoch` is backfilled on first poll, so orders persisted before this field existed start their clock at deploy rather than being exempt forever.

Timeouts route through the same progression rather than returning `UNEXPECTED_ERROR`.

### 4. Timeouts and retries for external calls

New `withTimeout()` and `withRetry()` helpers.

| Path | Bound | Rationale |
|---|---|---|
| `sendOrder` | 40s | ~12x observed p99 (3.4s); must stay under the 60s watchdog — enforced by a test, not a comment |
| `getLogs` (block path) | 30s | Serialised behind the watchdog, must fail fast |
| warm-up RPC | 180s + 5 retries w/ backoff | Pages over `pageSize` blocks with no watchdog running; a cold-start backfill is legitimately slow |

The warm-up bound is deliberately much looser than the block path. Retrying does not help an operation that is *consistently* slower than its deadline — every attempt hits the same wall, and the failure propagates to `process.exit(1)`, taking down every other chain. `withTimeout` clears its timer on both paths (verified by removing `clearTimeout` and confirming the test caught the leaked handle).

## Notes

**No migration required.** `createdAtEpoch`, `consecutiveApiFailures` and `lastApiError` are all optional; pruning doesn't change the storage format. Registry version stays at v2.

**First pass after deploy is expensive**: one ~220k-entry scan plus a 27.5 MB serialise. Every block after that is cheap.

**Known limitations, not addressed here:**
- Per-call timeouts bound a single call, not a whole block pass. A pass posting many slow orders can still exceed the watchdog.
- Per-order backoff can't distinguish "this order is broken" from "the API is down". A circuit breaker keyed on the API would recover faster from an outage.
- `withTimeout` abandons rather than cancels; the underlying request stays in flight until the socket closes.
- `InvalidAppData` keeps its existing fixed 60s backoff via `API_ERRORS_BACKOFF`.

## Tests

100 tests (up from 60), covering `escalatingRetryDelay`, `pruneExpiredOrders` (including malformed and non-hex uids), `watchdogSyncState`, `withTimeout`, `withRetry`, presign exemption and cut-off, failure-counter scoping, the chunked-write ordering, and the constant invariants that keep the timeouts from drifting apart.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Reliability**
  - Added time limits for order submission and blockchain RPC operations, preventing stalled processing.
  - Added automatic retries with increasing delays for temporary failures.
  - Improved watchdog recovery when block processing resumes.

- **Order Management**
  - Expired discrete orders are now removed automatically.
  - Order age is tracked consistently.
  - Repeated submission failures are tracked and handled with progressively later retries.

- **Error Handling**
  - Timeout failures are reported distinctly from unexpected errors, improving retry behavior and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->